### PR TITLE
Add time getter setter

### DIFF
--- a/src/ParticleSystem.ts
+++ b/src/ParticleSystem.ts
@@ -192,6 +192,14 @@ export class ParticleSystem {
     renderer: BatchedParticleRenderer;
     neededToUpdateRender: boolean;
 
+    set time(time:number) {
+        this.emissionState.time = time;
+    }
+
+    get time() : number {
+        return this.emissionState.time;
+    }
+
     get texture() {
         return this.rendererSettings.texture;
     }


### PR DESCRIPTION
Hello,

We started using quarks two days ago and it's awesome so far! 😊 We're using it in our threejs based engine with data exported directly from Unity (you can see a live example rendered using quarks [here](https://engine.needle.tools/docs/features-overview.html#particles-%E2%9C%A8) if you're curious)

For playing the particle effect with burst values again (and have quarks call the behaviours again after the system has reached the end time) I need to reset the time. 
This PR exposes accessors for the internal emission state.

