### PR TITLE
basic prewarm for looping particles

### DIFF
--- a/examples/meshMaterialDemo.js
+++ b/examples/meshMaterialDemo.js
@@ -37,6 +37,7 @@ export class MeshMaterialDemo extends Demo {
         let ps = new ParticleSystem({
             duration: 1,
             looping: true,
+            prewarm: true,
             instancingGeometry: geo,
             startLife: new IntervalValue(2.0, 3.0),
             startSpeed: new ConstantValue(1),

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prepublishOnly": "yarn run build:production",
     "deploy": "gh-pages -d examples",
     "docs": "typedoc",
-    "example": "http-server ./examples",
+    "example": "http-server ./examples -c-1 -p 8000",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:prod": "yarn run test -- --no-cache"

--- a/src/ParticleSystem.ts
+++ b/src/ParticleSystem.ts
@@ -176,7 +176,7 @@ export class ParticleSystem {
     autoDestroy: boolean;
 
     /**
-     * Determines whether the ParticleSystem should loop, i.e., restart emitting particles after the duration of the particle system is expired.
+     * Determines whether a looping ParticleSystem should prewarm, i.e., the Particle System looks like it has already simulated for one loop when first becoming visible.
      *
      * @type {boolean}
      */


### PR DESCRIPTION
This PR adds basic prewarm capabilities by simulating multiple `ParticleSystem.update()` steps. 

One small change to `package.json`: `yarn example` will always cache JS & HTML if we don't specify a port (see https://github.com/http-party/http-server/issues/149). 




## Mesh Material Demo
| w/o prewarm | w/ Prewarm |
|-------| ----|
| https://user-images.githubusercontent.com/5410441/224895512-a9aa27a4-826e-4114-8905-f34187518989.mov |  https://user-images.githubusercontent.com/5410441/224895606-1ab29ea7-f01f-4c5b-af31-dfc563fb1b7f.mov  |


## Tornado Demo (changes to `tornado.json` not committed)
| w/o prewarm | w/ Prewarm|
|---|---|
|https://user-images.githubusercontent.com/5410441/224896364-5b59e4b9-1c0b-43de-9c89-1540c636fdd3.mov |  https://user-images.githubusercontent.com/5410441/224896215-c856a114-47cd-470c-a38e-fcf2c7d6c66a.mov|










