### PR TITLE
Fix: allow higher three.js versions as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "homepage": "https://github.com/Alchemist0823/three.quarks#readme",
   "dependencies": {},
   "peerDependencies": {
-    "three": "^0.153.0"
+    "three": ">= 0.153.0"
   },
   "devDependencies": {
     "@babel/core": "^7.22.8",


### PR DESCRIPTION
Sorry to bring this up again, but turns out SemVer with 0.x versions is weird - ^0.153.0 only allows 0.153.x versions and not higher three.js versions. See https://semver.npmjs.com/ with `three`:

<img width="472" alt="image" src="https://github.com/Alchemist0823/three.quarks/assets/2693840/b3624f14-daf1-4c9c-9be8-1fc2f6f1c6e0">

Given three.js is unlikely to go to proper SemVer anytime soon, I think this works better:
`>= 0.153.0`
Or explicitly
`>= 0.153.0 && < 0.156.x` but that will require manual updates (and checks, of course) whenever three.js updates.

<img width="475" alt="image" src="https://github.com/Alchemist0823/three.quarks/assets/2693840/4334a09e-55bc-4e22-bb90-603b1ccd739f">

Thank you!