### PR TITLE
Fix scale mean formula when one axis is flipped

### DIFF
--- a/src/ParticleSystem.ts
+++ b/src/ParticleSystem.ts
@@ -612,7 +612,7 @@ export class ParticleSystem {
             }
             if (this.worldSpace) {
                 particle.position.applyMatrix4(matrix);
-                particle.startSize = (particle.startSize * (scale.x + scale.y + scale.z)) / 3;
+                particle.startSize = (particle.startSize * (Math.abs(scale.x) + Math.abs(scale.y) + Math.abs(scale.z))) / 3;
                 particle.size = particle.startSize;
                 particle.velocity.multiply(scale).applyMatrix3(this.normalMatrix);
                 if (particle.rotation && particle.rotation instanceof Quaternion) {

--- a/src/SpriteBatch.ts
+++ b/src/SpriteBatch.ts
@@ -316,7 +316,7 @@ export class SpriteBatch extends VFXBatch {
                     if (particle.parentMatrix) {
                         this.sizeBuffer.setX(index, particle.size);
                     } else {
-                        this.sizeBuffer.setX(index, (particle.size * (scale.x + scale.y + scale.z)) / 3);
+                        this.sizeBuffer.setX(index, (particle.size * (Math.abs(scale.x) + Math.abs(scale.y) + Math.abs(scale.z))) / 3);
                     }
                 }
                 this.uvTileBuffer.setX(index, particle.uvTile);

--- a/src/TrailBatch.ts
+++ b/src/TrailBatch.ts
@@ -246,8 +246,9 @@ export class TrailBatch extends VFXBatch {
                             this.widthBuffer.setX(index, current.size);
                             this.widthBuffer.setX(index + 1, current.size);
                         } else {
-                            this.widthBuffer.setX(index, (current.size * (scale.x + scale.y + scale.z)) / 3);
-                            this.widthBuffer.setX(index + 1, (current.size * (scale.x + scale.y + scale.z)) / 3);
+                            const objectScale = Math.abs(scale.x) + Math.abs(scale.y) + Math.abs(scale.z);
+                            this.widthBuffer.setX(index, current.size * objectScale);
+                            this.widthBuffer.setX(index + 1, current.size * objectScale);
                         }
                     }
 

--- a/src/TrailBatch.ts
+++ b/src/TrailBatch.ts
@@ -246,7 +246,7 @@ export class TrailBatch extends VFXBatch {
                             this.widthBuffer.setX(index, current.size);
                             this.widthBuffer.setX(index + 1, current.size);
                         } else {
-                            const objectScale = Math.abs(scale.x) + Math.abs(scale.y) + Math.abs(scale.z);
+                            const objectScale = (Math.abs(scale.x) + Math.abs(scale.y) + Math.abs(scale.z)) / 3;
                             this.widthBuffer.setX(index, current.size * objectScale);
                             this.widthBuffer.setX(index + 1, current.size * objectScale);
                         }


### PR DESCRIPTION
I'm maintaining an extension for GDevelop that uses three.quarks.
https://wiki.gdevelop.io/gdevelop5/extensions/particle-emitter3d/

GDevelop flips the Y axis to be consistent with its 2D rendering. Because of this, the scale is negative on one axis and the sum is 1 instead of 3. It results in particles being 3 times smaller than expected.

I guess that using absolute scale values should fix the issue.