### PR TITLE
Update Three.js to 157

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "three.quarks",
-  "version": "0.10.9",
+  "version": "0.10.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "three.quarks",
-      "version": "0.10.9",
+      "version": "0.10.18",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.22.11",
@@ -21,7 +21,7 @@
         "@rollup/plugin-typescript": "^11.1.3",
         "@types/jest": "^29.5.3",
         "@types/node": "^16.18.38",
-        "@types/three": "^0.153.0",
+        "@types/three": "^0.157.0",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "cpx": "^1.5.0",
@@ -35,14 +35,14 @@
         "prettier": "^3.0.0",
         "replace-in-file": "^7.0.1",
         "rollup": "^3.28.1",
-        "three": "^0.153.0",
+        "three": "^0.157.0",
         "ts-jest": "^29.1.1",
         "tslib": "^2.6.0",
         "typedoc": "^0.24.8",
         "typescript": "^4.9.5"
       },
       "peerDependencies": {
-        "three": ">=0.153.0"
+        "three": ">=0.157.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2984,12 +2984,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@tweenjs/tween.js": {
-      "version": "18.6.4",
-      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-18.6.4.tgz",
-      "integrity": "sha512-lB9lMjuqjtuJrx7/kOkqQBtllspPIN+96OvTCeJ2j5FEzinoAXTdAMFnDAQT1KVPRlnYfBrqxtqP66vDM40xxQ==",
-      "dev": true
-    },
     "node_modules/@types/babel__core": {
       "version": "7.1.16",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.16.tgz",
@@ -3134,16 +3128,15 @@
       "dev": true
     },
     "node_modules/@types/three": {
-      "version": "0.153.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.153.0.tgz",
-      "integrity": "sha512-L9quzIP4lsl6asDCw5zqN5opewCVOKRuB09apw5Acf2AIkoj5gLnUOY5AMB/ntFUt/QfFey0uKZaAd5t+HXSUw==",
+      "version": "0.157.2",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.157.2.tgz",
+      "integrity": "sha512-2kykrMgvO5LTAiahadM6ijoER+GcbEJ61pQVOyGxIJTCASoUnzwJvfhilsLxvEw4+glzhLYUDvvTvNjx+58Vzw==",
       "dev": true,
       "dependencies": {
-        "@tweenjs/tween.js": "~18.6.4",
         "@types/stats.js": "*",
         "@types/webxr": "*",
-        "fflate": "~0.6.9",
-        "lil-gui": "~0.17.0"
+        "fflate": "~0.6.10",
+        "meshoptimizer": "~0.18.1"
       }
     },
     "node_modules/@types/tough-cookie": {
@@ -8588,12 +8581,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lil-gui": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/lil-gui/-/lil-gui-0.17.0.tgz",
-      "integrity": "sha512-MVBHmgY+uEbmJNApAaPbtvNh1RCAeMnKym82SBjtp5rODTYKWtM+MXHCifLe2H2Ti1HuBGBtK/5SyG4ShQ3pUQ==",
-      "dev": true
-    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -8737,6 +8724,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "dev": true
     },
     "node_modules/micromatch": {
       "version": "2.3.11",
@@ -11145,9 +11138,9 @@
       "dev": true
     },
     "node_modules/three": {
-      "version": "0.153.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.153.0.tgz",
-      "integrity": "sha512-OCP2/uQR6GcDpSLnJt/3a4mdS0kNWcbfUXIwLoEMgLzEUIVIYsSDwskpmOii/AkDM+BBwrl6+CKgrjX9+E2aWg==",
+      "version": "0.157.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.157.0.tgz",
+      "integrity": "sha512-CeAwQrf4x3z0/e+MC4F+nXLW5t0gh3pw+L6CCBqpHvOq3bGYIgRYub7Pv0j/9wR+d++OiEglyZzWyuSYbwWGOA==",
       "dev": true
     },
     "node_modules/tmpl": {
@@ -14006,12 +13999,6 @@
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true
     },
-    "@tweenjs/tween.js": {
-      "version": "18.6.4",
-      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-18.6.4.tgz",
-      "integrity": "sha512-lB9lMjuqjtuJrx7/kOkqQBtllspPIN+96OvTCeJ2j5FEzinoAXTdAMFnDAQT1KVPRlnYfBrqxtqP66vDM40xxQ==",
-      "dev": true
-    },
     "@types/babel__core": {
       "version": "7.1.16",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.16.tgz",
@@ -14156,16 +14143,15 @@
       "dev": true
     },
     "@types/three": {
-      "version": "0.153.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.153.0.tgz",
-      "integrity": "sha512-L9quzIP4lsl6asDCw5zqN5opewCVOKRuB09apw5Acf2AIkoj5gLnUOY5AMB/ntFUt/QfFey0uKZaAd5t+HXSUw==",
+      "version": "0.157.2",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.157.2.tgz",
+      "integrity": "sha512-2kykrMgvO5LTAiahadM6ijoER+GcbEJ61pQVOyGxIJTCASoUnzwJvfhilsLxvEw4+glzhLYUDvvTvNjx+58Vzw==",
       "dev": true,
       "requires": {
-        "@tweenjs/tween.js": "~18.6.4",
         "@types/stats.js": "*",
         "@types/webxr": "*",
-        "fflate": "~0.6.9",
-        "lil-gui": "~0.17.0"
+        "fflate": "~0.6.10",
+        "meshoptimizer": "~0.18.1"
       }
     },
     "@types/tough-cookie": {
@@ -18217,12 +18203,6 @@
         "type-check": "~0.4.0"
       }
     },
-    "lil-gui": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/lil-gui/-/lil-gui-0.17.0.tgz",
-      "integrity": "sha512-MVBHmgY+uEbmJNApAaPbtvNh1RCAeMnKym82SBjtp5rODTYKWtM+MXHCifLe2H2Ti1HuBGBtK/5SyG4ShQ3pUQ==",
-      "dev": true
-    },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -18338,6 +18318,12 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
+    "meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
       "dev": true
     },
     "micromatch": {
@@ -20209,9 +20195,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.153.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.153.0.tgz",
-      "integrity": "sha512-OCP2/uQR6GcDpSLnJt/3a4mdS0kNWcbfUXIwLoEMgLzEUIVIYsSDwskpmOii/AkDM+BBwrl6+CKgrjX9+E2aWg==",
+      "version": "0.157.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.157.0.tgz",
+      "integrity": "sha512-CeAwQrf4x3z0/e+MC4F+nXLW5t0gh3pw+L6CCBqpHvOq3bGYIgRYub7Pv0j/9wR+d++OiEglyZzWyuSYbwWGOA==",
       "dev": true
     },
     "tmpl": {

--- a/package.json
+++ b/package.json
@@ -52,9 +52,8 @@
     "url": "https://github.com/Alchemist0823/three.quarks/issues"
   },
   "homepage": "https://github.com/Alchemist0823/three.quarks#readme",
-  "dependencies": {},
   "peerDependencies": {
-    "three": ">=0.153.0"
+    "three": ">=0.157.0"
   },
   "devDependencies": {
     "@babel/core": "^7.22.11",
@@ -69,7 +68,7 @@
     "@rollup/plugin-typescript": "^11.1.3",
     "@types/jest": "^29.5.3",
     "@types/node": "^16.18.38",
-    "@types/three": "^0.153.0",
+    "@types/three": "^0.157.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "cpx": "^1.5.0",
@@ -83,7 +82,7 @@
     "prettier": "^3.0.0",
     "replace-in-file": "^7.0.1",
     "rollup": "^3.28.1",
-    "three": "^0.153.0",
+    "three": "^0.157.0",
     "ts-jest": "^29.1.1",
     "tslib": "^2.6.0",
     "typedoc": "^0.24.8",

--- a/src/ParticleEmitter.ts
+++ b/src/ParticleEmitter.ts
@@ -1,4 +1,4 @@
-import {Object3D, BaseEvent} from 'three';
+import {Object3D, Object3DEventMap} from 'three';
 import {IParticleSystem, SerializationOptions} from './BatchedRenderer';
 
 export interface MetaData {
@@ -12,7 +12,7 @@ export interface MetaData {
     nodes: {[key: string]: any};
 }
 
-export class ParticleEmitter<E extends BaseEvent> extends Object3D<E> {
+export class ParticleEmitter<E extends Object3DEventMap = Object3DEventMap> extends Object3D<E> {
     type = 'ParticleEmitter';
     system: IParticleSystem;
     //interleavedBuffer: InterleavedBuffer;

--- a/src/ParticleSystem.ts
+++ b/src/ParticleSystem.ts
@@ -18,7 +18,7 @@ import {MetaData, ParticleEmitter} from './ParticleEmitter';
 import {EmitterFromJSON, EmitterShape, ShapeJSON, SphereEmitter} from './shape';
 import {
     AdditiveBlending,
-    BaseEvent,
+    Object3DEventMap,
     Blending,
     BufferGeometry,
     DoubleSide,
@@ -308,9 +308,9 @@ export class ParticleSystem implements IParticleSystem {
     /**
      * the emitter object that should be added in the scene.
      *
-     * @type {ParticleEmitter<BaseEvent>}
+     * @type {ParticleEmitter<Object3DEventMap>}
      */
-    emitter: ParticleEmitter<BaseEvent>;
+    emitter: ParticleEmitter<Object3DEventMap>;
 
     /**
      * the VFX renderer settings for the batch renderer

--- a/src/QuarksLoader.ts
+++ b/src/QuarksLoader.ts
@@ -31,6 +31,7 @@ import {
     Points,
     SpriteMaterial,
     Bone,
+    Object3DEventMap,
 } from 'three';
 import {ParticleSystem} from './ParticleSystem';
 import {Behavior, EmitSubParticleSystem} from './behaviors';
@@ -56,7 +57,7 @@ export class QuarksLoader extends ObjectLoader {
         });
         object.traverse(function (child) {
             if (child.type === 'ParticleEmitter') {
-                const system = (child as ParticleEmitter<Event>).system as ParticleSystem;
+                const system = (child as ParticleEmitter).system as ParticleSystem;
                 const shape = system.emitterShape;
                 /*if (shape instanceof MeshSurfaceEmitter) {
                     shape.geometry = objectsMap[shape.geometry as any] as Mesh;
@@ -65,7 +66,7 @@ export class QuarksLoader extends ObjectLoader {
                     if (system.behaviors[i] instanceof EmitSubParticleSystem) {
                         (system.behaviors[i] as EmitSubParticleSystem).subParticleSystem = objectsMap[
                             (system.behaviors[i] as EmitSubParticleSystem).subParticleSystem as any
-                        ] as ParticleEmitter<Event>;
+                        ] as ParticleEmitter;
                     }
                 }
             }
@@ -79,7 +80,7 @@ export class QuarksLoader extends ObjectLoader {
     }
 
     // @ts-ignore
-    parseObject<T extends Object3D<Event>>(
+    parseObject<T extends Object3D<Object3DEventMap>>(
         data: any,
         geometries: any,
         materials: Material[],

--- a/src/behaviors/EmitSubParticleSystem.ts
+++ b/src/behaviors/EmitSubParticleSystem.ts
@@ -1,7 +1,7 @@
 import {Behavior} from './Behavior';
 import {Particle} from '../Particle';
 import {EmissionState, ParticleSystem} from '../ParticleSystem';
-import {BaseEvent, Matrix4, Quaternion, Vector3} from 'three';
+import {Object3DEventMap, Matrix4, Quaternion, Vector3} from 'three';
 import {ParticleEmitter} from '../ParticleEmitter';
 
 const VECTOR_ONE = new Vector3(1, 1, 1);
@@ -31,7 +31,7 @@ export class EmitSubParticleSystem implements Behavior {
     constructor(
         private particleSystem: ParticleSystem,
         public useVelocityAsBasis: boolean,
-        public subParticleSystem: ParticleEmitter<BaseEvent> | undefined,
+        public subParticleSystem: ParticleEmitter<Object3DEventMap> | undefined,
         public mode: SubParticleEmitMode = SubParticleEmitMode.Frame,
         public emitProbability: number = 1
     ) {

--- a/src/nodes/NodeVFX.ts
+++ b/src/nodes/NodeVFX.ts
@@ -1,7 +1,7 @@
 import {IParticle, NodeParticle, Particle, SpriteParticle, TrailParticle} from '../Particle';
 import {ParticleEmitter} from '../ParticleEmitter';
 import {
-    BaseEvent,
+    Object3DEventMap,
     BufferGeometry,
     Layers,
     Material,
@@ -114,9 +114,9 @@ export class NodeVFX implements IParticleSystem {
     /**
      * the emitter object that should be added in the scene.
      *
-     * @type {ParticleEmitter<BaseEvent>}
+     * @type {ParticleEmitter<Object3DEventMap>}
      */
-    emitter: ParticleEmitter<BaseEvent>;
+    emitter: ParticleEmitter<Object3DEventMap>;
 
     /**
      * the VFX renderer settings for the batch renderer

--- a/test/ParticleEmitter.test.ts
+++ b/test/ParticleEmitter.test.ts
@@ -115,7 +115,7 @@ describe('ParticleEmitter', () => {
         const json = glowBeam.emitter.toJSON();
         // console.log(json);
         const loader = new QuarksLoader();
-        const emitter = loader.parse(json, () => {}) as ParticleEmitter<Event>;
+        const emitter = loader.parse(json, () => {}) as ParticleEmitter;
         const system = emitter.system as ParticleSystem;
         expect(system.rendererSettings.layers.mask).toBe(3);
         expect(system.startTileIndex.type).toBe('value');

--- a/test/QuarksLoader.test.ts
+++ b/test/QuarksLoader.test.ts
@@ -12,7 +12,7 @@ describe('QuarksLoader', () => {
         const loader = new QuarksLoader();
         const object = loader.parse(JSON1, () => {});
         expect(object.children.length).toBe(2);
-        const system = (object.children[0] as ParticleEmitter<Event>).system as ParticleSystem;
+        const system = (object.children[0] as ParticleEmitter).system as ParticleSystem;
         expect(system.behaviors.length).toBe(1);
         expect((system.behaviors[0] as any).particleSystem).toBe(system);
         expect((system.behaviors[0] as EmitSubParticleSystem).subParticleSystem).toBe(object.children[1]);
@@ -25,10 +25,8 @@ describe('QuarksLoader', () => {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         expect(
             Object.keys(
-                (
-                    ((object.children[1] as ParticleEmitter<Event>).system as ParticleSystem)
-                        .emitterShape as MeshSurfaceEmitter
-                ).geometry!.attributes
+                (((object.children[1] as ParticleEmitter).system as ParticleSystem).emitterShape as MeshSurfaceEmitter)
+                    .geometry!.attributes
             ).length
         ).toBe(3);
     });


### PR DESCRIPTION
Originally this branch was made to fix startColor for colorRange but sadly you beat me to the punch an hour ago. 

_(Side Note: I do think the fix I utilized would be more accurate. There is already a RandomColor range available. I implemented colorRange to linearly step through the lerp so that we actually spread the two colors across all spawned particles. )_

Anyway, I updated the three.js dependency. I updated to the new Object3D event types. Also gave ParticleEmitter a default event type.