### PR TITLE
Upgrade Three.js from 0.165.0 to 0.182.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1822,6 +1822,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@emnapi/core": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.3.1.tgz",
@@ -4131,7 +4138,9 @@
       }
     },
     "node_modules/@tweenjs/tween.js": {
-      "version": "23.1.2",
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4307,15 +4316,19 @@
       "license": "MIT"
     },
     "node_modules/@types/three": {
-      "version": "0.165.0",
+      "version": "0.182.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.182.0.tgz",
+      "integrity": "sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tweenjs/tween.js": "~23.1.1",
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
         "@types/stats.js": "*",
-        "@types/webxr": "*",
+        "@types/webxr": ">=0.5.17",
+        "@webgpu/types": "*",
         "fflate": "~0.8.2",
-        "meshoptimizer": "~0.18.1"
+        "meshoptimizer": "~0.22.0"
       }
     },
     "node_modules/@types/tough-cookie": {
@@ -4539,6 +4552,13 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.69",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
+      "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -11474,7 +11494,9 @@
       }
     },
     "node_modules/meshoptimizer": {
-      "version": "0.18.1",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
       "dev": true,
       "license": "MIT"
     },
@@ -15219,29 +15241,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/three": {
-      "version": "0.165.0",
-      "license": "MIT"
-    },
-    "node_modules/three-stdlib": {
-      "version": "2.35.13",
-      "license": "MIT",
-      "dependencies": {
-        "@types/draco3d": "^1.4.0",
-        "@types/offscreencanvas": "^2019.6.4",
-        "@types/webxr": "^0.5.2",
-        "draco3d": "^1.4.1",
-        "fflate": "^0.6.9",
-        "potpack": "^1.0.1"
-      },
-      "peerDependencies": {
-        "three": ">=0.128.0"
-      }
-    },
-    "node_modules/three-stdlib/node_modules/fflate": {
-      "version": "0.6.10",
-      "license": "MIT"
-    },
     "node_modules/three.quarks": {
       "resolved": "packages/three.quarks",
       "link": true
@@ -16640,15 +16639,21 @@
         "three.quarks": "^0.15.3"
       },
       "devDependencies": {
-        "@types/three": "^0.165.0",
+        "@types/three": "^0.182.0",
         "@types/webxr": "^0.5.16",
-        "three": "^0.165.0"
+        "three": "^0.182.0"
       }
     },
     "packages/quarks.nodes/node_modules/quarks.core": {
       "version": "0.15.7",
       "resolved": "https://registry.npmjs.org/quarks.core/-/quarks.core-0.15.7.tgz",
       "integrity": "sha512-79+vnVTXHVAZ2PPIvE5yhMYFeOMSjP7K3cC4mHELmNtGs0DehZaZPSp8q9Lv6Z72bvcHKyme7/HH0Eqw+Hh5AA==",
+      "license": "MIT"
+    },
+    "packages/quarks.nodes/node_modules/three": {
+      "version": "0.182.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.182.0.tgz",
+      "integrity": "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==",
       "license": "MIT"
     },
     "packages/quarks.nodes/node_modules/three.quarks": {
@@ -16666,12 +16671,42 @@
     "packages/quarks.playground": {
       "version": "0.1.0",
       "dependencies": {
-        "three": "^0.165.0",
-        "three-stdlib": "^2.35.13",
+        "three": "^0.182.0",
+        "three-stdlib": "^2.36.1",
         "three.quarks": "*"
       },
       "devDependencies": {
+        "@types/three": "^0.182.0",
         "vite": "^6.0.5"
+      }
+    },
+    "packages/quarks.playground/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
+    },
+    "packages/quarks.playground/node_modules/three": {
+      "version": "0.182.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.182.0.tgz",
+      "integrity": "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==",
+      "license": "MIT"
+    },
+    "packages/quarks.playground/node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
       }
     },
     "packages/three.quarks": {
@@ -16682,12 +16717,19 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
-        "@types/three": "^0.165.0",
-        "three": "^0.165.0"
+        "@types/three": "^0.182.0",
+        "three": "^0.182.0"
       },
       "peerDependencies": {
-        "three": ">=0.165.0"
+        "three": ">=0.182.0"
       }
+    },
+    "packages/three.quarks/node_modules/three": {
+      "version": "0.182.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.182.0.tgz",
+      "integrity": "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/packages/quarks.core/rollup.config.js
+++ b/packages/quarks.core/rollup.config.js
@@ -1,7 +1,7 @@
 import {nodeResolve} from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs'
 import terser from '@rollup/plugin-terser';
-import pkg from './package.json' assert {type: 'json'};
+import pkg from './package.json' with {type: 'json'};
 import typescript from '@rollup/plugin-typescript';
 import ts from 'typescript';
 

--- a/packages/quarks.nodes/package.json
+++ b/packages/quarks.nodes/package.json
@@ -7,9 +7,9 @@
     "three.quarks": "^0.15.3"
   },
   "devDependencies": {
-    "@types/three": "^0.165.0",
+    "@types/three": "^0.182.0",
     "@types/webxr": "^0.5.16",
-    "three": "^0.165.0"
+    "three": "^0.182.0"
   },
   "types": "./dist/types/index.d.ts",
   "main": "./dist/quarks.nodes.cjs",

--- a/packages/quarks.nodes/rollup.config.js
+++ b/packages/quarks.nodes/rollup.config.js
@@ -2,7 +2,7 @@ import resolve from '@rollup/plugin-node-resolve';
 //import commonjs from '@rollup/plugin-commonjs'
 import babel from '@rollup/plugin-babel';
 import terser from '@rollup/plugin-terser';
-import pkg from './package.json' assert {type: 'json'};
+import pkg from './package.json' with {type: 'json'};
 
 const date = new Date().toDateString();
 

--- a/packages/quarks.nodes/src/WebGPURenderer.ts
+++ b/packages/quarks.nodes/src/WebGPURenderer.ts
@@ -377,7 +377,7 @@ export class WebGPURenderer {
 
         const swapChainTexture = this.context.getCurrentTexture();
         // prettier-ignore
-        this.renderPassDescriptor.colorAttachments[0]!.view = swapChainTexture.createView();
+        (this.renderPassDescriptor.colorAttachments as GPURenderPassColorAttachment[])[0]!.view = swapChainTexture.createView();
 
         const commandEncoder = this.deviceContext.device.createCommandEncoder();
         {

--- a/packages/quarks.playground/package.json
+++ b/packages/quarks.playground/package.json
@@ -10,11 +10,12 @@
     "preview": "vite preview --port 8001"
   },
   "devDependencies": {
+    "@types/three": "^0.182.0",
     "vite": "^6.0.5"
   },
   "dependencies": {
-    "three": "^0.165.0",
-    "three-stdlib": "^2.35.13",
+    "three": "^0.182.0",
+    "three-stdlib": "^2.36.1",
     "three.quarks": "*"
   }
 }

--- a/packages/three.quarks/package.json
+++ b/packages/three.quarks/package.json
@@ -56,14 +56,14 @@
   },
   "homepage": "https://quarks.art",
   "peerDependencies": {
-    "three": ">=0.165.0"
+    "three": ">=0.182.0"
   },
   "dependencies": {
     "quarks.core": "^0.16.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
-    "@types/three": "^0.165.0",
-    "three": "^0.165.0"
+    "@types/three": "^0.182.0",
+    "three": "^0.182.0"
   }
 }

--- a/packages/three.quarks/rollup.config.js
+++ b/packages/three.quarks/rollup.config.js
@@ -4,7 +4,7 @@ import babel from '@rollup/plugin-babel';
 import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 import ts from 'typescript';
-import pkg from './package.json' assert {type: 'json'};
+import pkg from './package.json' with {type: 'json'};
 
 const date = new Date().toDateString();
 

--- a/packages/three.quarks/src/ParticleEmitter.ts
+++ b/packages/three.quarks/src/ParticleEmitter.ts
@@ -76,7 +76,7 @@ export class ParticleEmitter<E extends Object3DEventMap = Object3DEventMap>exten
         this.children = this.children.filter((child) => child.type !== 'ParticleSystemPreview');
         const data = super.toJSON(meta);
         this.children = children;
-        if (this.system !== null) data.object.ps = this.system.toJSON(meta!, options);
+        if (this.system !== null) (data.object as any).ps = this.system.toJSON(meta!, options);
         return data;
     }
 }

--- a/packages/three.quarks/src/ParticleSystem.ts
+++ b/packages/three.quarks/src/ParticleSystem.ts
@@ -1158,7 +1158,7 @@ export class ParticleSystem implements IParticleSystem {
                 const image = this.texture.source;
                 meta.images[image.uuid] = {
                     uuid: image.uuid,
-                    url: this.texture.image.url,
+                    url: (this.texture.image as {url?: string}).url,
                 };
             }
         }

--- a/packages/three.quarks/src/QuarksLoader.ts
+++ b/packages/three.quarks/src/QuarksLoader.ts
@@ -19,6 +19,7 @@ import {
     RectAreaLight,
     HemisphereLight,
     LightProbe,
+    SphericalHarmonics3,
     SpotLight,
     SkinnedMesh,
     Mesh,
@@ -239,7 +240,10 @@ export class QuarksLoader extends ObjectLoader {
                 break;
 
             case 'LightProbe':
-                object = new LightProbe().fromJSON(data);
+                object = new LightProbe();
+                if (data.sh !== undefined) {
+                    object.sh = new SphericalHarmonics3().fromArray(data.sh);
+                }
 
                 break;
 

--- a/packages/three.quarks/src/QuarksPrefab.ts
+++ b/packages/three.quarks/src/QuarksPrefab.ts
@@ -367,7 +367,7 @@ export class QuarksPrefab extends Group implements IPrefab {
         const json = super.toJSON();
         
         // Add animations data
-        json.object.animationData = this.animationData.map(anim => ({
+        (json.object as any).animationData = this.animationData.map(anim => ({
             startTime: anim.startTime,
             duration: anim.duration,
             type: anim.type,


### PR DESCRIPTION
- Update three and @types/three to ^0.182.0 in all packages
- Update three-stdlib to ^2.36.1 in quarks.playground
- Add @types/three to quarks.playground devDependencies
- Fix rollup configs: change 'assert' to 'with' for JSON imports (Node 22 compatibility)
- Fix TypeScript errors for Three.js API changes:
  - Cast data.object to any for custom properties in serialization (ParticleEmitter, QuarksPrefab)
  - Cast texture.image to typed object for url property (ParticleSystem)
  - Update LightProbe instantiation to manually set SphericalHarmonics3 (QuarksLoader)
  - Cast colorAttachments to array type in WebGPURenderer (quarks.nodes)

https://claude.ai/code/session_01NP5pM8FETsdCV6ovYkA4hw