### PR TITLE
ESM/NodeNext-compatible built .d.ts

### DIFF
--- a/packages/quarks.core/package.json
+++ b/packages/quarks.core/package.json
@@ -19,8 +19,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "clean": "rimraf dist",
-    "build:types": "tsc --emitDeclarationOnly",
+    "clean": "rimraf dist .rollup.cache tsconfig.tsbuildinfo",
+    "build:types": "tsc --emitDeclarationOnly && node ../../scripts/fix-dts-extensions.mjs dist/types",
     "build:js": "cross-env NODE_ENV=production rollup -c",
     "yalc:publish": "node -e \"const os = require('os'); const { execSync } = require('child_process'); const homedir = os.homedir(); execSync(`yalc publish --store-folder ${homedir}/.yalc`, {stdio: 'inherit'});\"",
     "build": "npm run clean && npm run build:types && npm run build:js",

--- a/packages/quarks.core/rollup.config.js
+++ b/packages/quarks.core/rollup.config.js
@@ -32,7 +32,8 @@ export const lib = {
             }),
             typescript({
                 typescript: ts,
-                declaration: true,
+                declaration: false,
+                composite: false,
             }),
         ],
         output: [

--- a/packages/quarks.examples/package.json
+++ b/packages/quarks.examples/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "vite --port 8000",
+    "dev": "vite --port 8000 --host",
     "build": "vite build",
     "preview": "vite preview --port 8000",
     "test": ""

--- a/packages/quarks.nodes/package.json
+++ b/packages/quarks.nodes/package.json
@@ -27,8 +27,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "clean": "rimraf dist",
-    "build:types": "tsc --emitDeclarationOnly",
+    "clean": "rimraf dist .rollup.cache tsconfig.tsbuildinfo",
+    "build:types": "tsc --emitDeclarationOnly && node ../../scripts/fix-dts-extensions.mjs dist/types",
     "build:js": "cross-env NODE_ENV=production rollup -c",
     "build": "npm run clean && npm run build:types && npm run build:js",
     "test": "jest",

--- a/packages/quarks.r3f/package.json
+++ b/packages/quarks.r3f/package.json
@@ -19,10 +19,10 @@
     "LICENSE"
   ],
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "rimraf dist .rollup.cache tsconfig.tsbuildinfo",
     "type-check": "tsc --noEmit",
     "dev": "rollup -c -w",
-    "build:types": "tsc --emitDeclarationOnly",
+    "build:types": "tsc --emitDeclarationOnly && node ../../scripts/fix-dts-extensions.mjs dist/types",
     "build:js": "rollup -c",
     "build": "npm run clean && npm run build:types && cross-env NODE_ENV=production npm run build:js",
     "test": "jest --passWithNoTests",

--- a/packages/quarks.r3f/rollup.config.js
+++ b/packages/quarks.r3f/rollup.config.js
@@ -39,7 +39,8 @@ export const lib = {
             }),
             typescript({
                 typescript: ts,
-                declaration: true,
+                declaration: false,
+                composite: false,
             }),
         ],
         output: [

--- a/packages/three.quarks/package.json
+++ b/packages/three.quarks/package.json
@@ -20,11 +20,11 @@
     "LICENSE"
   ],
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "rimraf dist .rollup.cache tsconfig.tsbuildinfo",
     "type-check": "tsc --noEmit",
     "type-check:watch": "npm run type-check -- --watch",
     "dev": "rollup -c -w",
-    "build:types": "tsc --emitDeclarationOnly",
+    "build:types": "tsc --emitDeclarationOnly && node ../../scripts/fix-dts-extensions.mjs dist/types",
     "build:js": "rollup -c",
     "yalc:publish": "node -e \"const os = require('os'); const { execSync } = require('child_process'); const homedir = os.homedir(); execSync(`yalc publish --store-folder ${homedir}/.yalc`, {stdio: 'inherit'});\"",
     "build": "npm run clean && npm run build:types && cross-env NODE_ENV=production npm run build:js",

--- a/packages/three.quarks/rollup.config.js
+++ b/packages/three.quarks/rollup.config.js
@@ -47,7 +47,8 @@ export const lib = {
             }),
             typescript({
                 typescript: ts,
-                declaration: true,
+                declaration: false,
+                composite: false,
             }),
         ],
         output: [

--- a/scripts/fix-dts-extensions.mjs
+++ b/scripts/fix-dts-extensions.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const targetDir = path.resolve(process.argv[2] ?? 'dist/types');
+
+if (!fs.existsSync(targetDir)) {
+    console.error(`fix-dts-extensions: ${targetDir} does not exist`);
+    process.exit(1);
+}
+
+const walk = (dir) =>
+    fs.readdirSync(dir, { withFileTypes: true }).flatMap((d) => {
+        const p = path.join(dir, d.name);
+        return d.isDirectory() ? walk(p) : [p];
+    });
+
+let fixed = 0;
+for (const file of walk(targetDir).filter((f) => f.endsWith('.d.ts'))) {
+    const dir = path.dirname(file);
+    const original = fs.readFileSync(file, 'utf8');
+    const next = original.replace(
+        /(from\s+['"])(\.[^'"]+)(['"])/g,
+        (_, pre, spec, post) => {
+            if (fs.existsSync(path.join(dir, `${spec}.d.ts`))) {
+                return `${pre}${spec}.js${post}`;
+            }
+            const idxRel = spec.endsWith('/') ? `${spec}index.d.ts` : `${spec}/index.d.ts`;
+            if (fs.existsSync(path.join(dir, idxRel))) {
+                return `${pre}${spec}${spec.endsWith('/') ? '' : '/'}index.js${post}`;
+            }
+            return `${pre}${spec}${post}`;
+        },
+    );
+    if (next !== original) {
+        fs.writeFileSync(file, next);
+        fixed++;
+    }
+}
+
+console.log(`fix-dts-extensions: rewrote ${fixed} file(s) in ${path.relative(process.cwd(), targetDir)}`);


### PR DESCRIPTION
Fixes consumer breakage under `moduleResolution: "nodenext"` / `"node16"` by adding `.js` extensions to relative import statements in the built `.d.ts` files. Also fixes a stale-cache bug in `clean` that left `dist/types/` near-empty after a rebuild.

Per the [[TypeScript handbook](https://www.typescriptlang.org/docs/handbook/modules/reference.html#module-syntax)](https://www.typescriptlang.org/docs/handbook/modules/reference.html#module-syntax), explicit `.js` extensions on relative imports are the standard ESM module syntax going forward:

```ts
// @Filename: main.ts
import { f, type SomeInterface } from "./module.js";
import type { SomeType } from "./module.js";
```

---

## Diffs

### 1. New `scripts/fix-dts-extensions.mjs` (+~40 lines)

Post-`tsc` walker that adds `.js` (or `/index.js`) to relative imports in emitted `.d.ts` files, by probing for sibling `.d.ts` existence.

*Why:* `tsc --emitDeclarationOnly` preserves source's extensionless imports; NodeNext/Node16 consumers can't resolve them.

### 2. `build:types` extended in 4 publishable packages

Same edit applied to `packages/quarks.core/package.json`, `packages/three.quarks/package.json`, `packages/quarks.r3f/package.json`, `packages/quarks.nodes/package.json`:

```diff
- "build:types": "tsc --emitDeclarationOnly",
+ "build:types": "tsc --emitDeclarationOnly && node ../../scripts/fix-dts-extensions.mjs dist/types",
```

*Why:* run the fixup immediately after declaration emit, before anything else touches `dist/types/`.

### 3. `clean` extended in same 4 packages

```diff
- "clean": "rimraf dist",
+ "clean": "rimraf dist .rollup.cache tsconfig.tsbuildinfo",
```

*Why:* both caches sit outside `dist/`. After a `clean`, stale `tsconfig.tsbuildinfo` (composite incremental) and `.rollup.cache/` made tsc and `@rollup/plugin-typescript` think source was unchanged, emitting one or zero `.d.ts` files. Downstream packages then failed with `TS7016 Could not find a declaration file for module 'quarks.core'`.

### 4. Stop emitting declarations from rollup in 3 packages

`packages/quarks.core/rollup.config.js`, `packages/three.quarks/rollup.config.js`, `packages/quarks.r3f/rollup.config.js`:

```diff
  typescript({
      typescript: ts,
-     declaration: true,
+     declaration: false,
+     composite: false,
  }),
```

(`quarks.nodes` uses babel, not `@rollup/plugin-typescript`, so no change there.)

*Why:* tsc and the rollup plugin were both writing `.d.ts` into `dist/types/` and clobbering each other. tsc now owns declarations end-to-end; rollup just bundles JS. Also silences the `"outputToFilesystem option is defaulting to true"` warning. `composite: false` is required because TS rejects `declaration: false` when `composite: true` (composite is set in the shared `tsconfig.package.json` for typedoc).

### 5. (Optional — split if preferred) Vite dev server for Docker

`packages/quarks.examples/package.json`:

```diff
- "dev": "vite --port 8000",
+ "dev": "vite --port 8000 --host",
```

*Why:* unrelated Docker dev fix. Vite defaults to binding `127.0.0.1`, which isn't reachable via `-p 8000:8000`. `--host` makes it bind `0.0.0.0`.