### PR TITLE
three.quarks cleanup and targeted fixes

### DIFF
--- a/packages/three.quarks/src/BatchedRenderer.ts
+++ b/packages/three.quarks/src/BatchedRenderer.ts
@@ -1,72 +1,11 @@
 import {IParticleSystem} from 'quarks.core';
-import {BufferGeometry, Layers, Material, Object3D, Texture} from 'three';
+import {Object3D, Texture} from 'three';
 import {ParticleSystem} from './ParticleSystem';
 import {SpriteBatch} from './SpriteBatch';
 import {TrailBatch} from './TrailBatch';
-import {RenderMode, StoredBatchSettings, VFXBatch} from './VFXBatch';
+import {RenderMode, VFXBatch, type StoredBatchSettings, type VFXBatchSettings} from './VFXBatch';
 
-/**
- * Settings for rendering a batch of VFX systems.
- */
-export interface VFXBatchSettings {
-    /**
-     * Geometry for instancing.
-     * @type {BufferGeometry}
-     */
-    instancingGeometry: BufferGeometry;
-    /**
-     * Material for rendering.
-     * @type {Material}
-     */
-    material: Material;
-    /**
-     * Number of horizontal tiles in the texture.
-     * @type {number}
-     */
-    uTileCount: number;
-    /**
-     * Number of vertical tiles in the texture.
-     * @type {number}
-     */
-    vTileCount: number;
-    /**
-     * Whether to blend tiles.
-     * @type {boolean}
-     */
-    blendTiles: boolean;
-    /**
-     * Enable soft particles.
-     * @type {boolean}
-     */
-    softParticles: boolean;
-    /**
-     * Near fade distance for soft particles.
-     * @type {number}
-     */
-    softNearFade: number;
-    /**
-     * Far fade distance for soft particles.
-     * @type {number}
-     */
-    softFarFade: number;
-    /**
-     * Render mode.
-     * @type {RenderMode}
-     */
-    renderMode: RenderMode;
-    /**
-     * Render order.
-     * @type {number}
-     */
-    renderOrder: number;
-    /**
-     * Layers control the visibility of the object.
-     * @type {Layers}
-     * @see {@link https://threejs.org/docs/index.html#api/en/core/Layers | Official Documentation}
-     * @see {@link https://github.com/mrdoob/three.js/blob/master/src/core/Layers.js | Source}
-     */
-    layers: Layers;
-}
+export type {VFXBatchSettings} from './VFXBatch';
 
 /**
  * Batches particle systems that share compatible render settings.

--- a/packages/three.quarks/src/BatchedRenderer.ts
+++ b/packages/three.quarks/src/BatchedRenderer.ts
@@ -1,18 +1,12 @@
-import {VFXBatch, RenderMode, StoredBatchSettings} from './VFXBatch';
-import {
-    BufferGeometry,
-    Layers,
-    Material,
-    Object3D,
-    Texture,
-} from 'three';
+import {IParticleSystem} from 'quarks.core';
+import {BufferGeometry, Layers, Material, Object3D, Texture} from 'three';
+import {ParticleSystem} from './ParticleSystem';
 import {SpriteBatch} from './SpriteBatch';
 import {TrailBatch} from './TrailBatch';
-import {IParticleSystem} from 'quarks.core';
-import {ParticleSystem} from './ParticleSystem';
+import {RenderMode, StoredBatchSettings, VFXBatch} from './VFXBatch';
 
 /**
- * the settings for rendering a batch of VFX system.
+ * Settings for rendering a batch of VFX systems.
  */
 export interface VFXBatchSettings {
     /**
@@ -66,7 +60,7 @@ export interface VFXBatchSettings {
      */
     renderOrder: number;
     /**
-     * layers control visibility of the object.
+     * Layers control the visibility of the object.
      * @type {Layers}
      * @see {@link https://threejs.org/docs/index.html#api/en/core/Layers | Official Documentation}
      * @see {@link https://github.com/mrdoob/three.js/blob/master/src/core/Layers.js | Source}
@@ -74,36 +68,138 @@ export interface VFXBatchSettings {
     layers: Layers;
 }
 
-
 /**
- * the class represents the batch renderer. a three.js scene should only have one batchedRenderer
- * It keeps references of all particle systems and rendering batch.
- * It batches all particle systems that has the same rendering pipeline to a single VFXBatch.
+ * Batches particle systems that share compatible render settings.
+ *
+ * A scene should generally use one BatchedRenderer. Registered systems are grouped
+ * into VFXBatch instances by material, geometry, render mode, tiling, soft-particle
+ * settings, render order, and layers.
  */
 export class BatchedRenderer extends Object3D {
+    readonly type = 'BatchedRenderer';
+
     /**
      * Batches for rendering.
-     * @type {Array<VFXBatch>}
+     * @type {VFXBatch[]}
      */
-    batches: Array<VFXBatch> = [];
+    readonly batches: VFXBatch[] = [];
+
     /**
      * Map of systems to batch indices.
      * @type {Map<IParticleSystem, number>}
      */
-    systemToBatchIndex: Map<IParticleSystem, number> = new Map<IParticleSystem, number>();
-    type = 'BatchedRenderer';
+    private readonly systemToBatchIndex: Map<IParticleSystem, number> = new Map();
 
     /**
      * Depth texture.
      * @type {Texture | null}
      */
-    depthTexture: Texture | null = null;
+    private depthTexture: Texture | null = null;
 
     constructor() {
         super();
     }
 
-    private static equals(a: StoredBatchSettings, b: VFXBatchSettings) {
+    /**
+     * Adds a particle system to a batch.
+     * @param {IParticleSystem} system - The particle system to add.
+     */
+    addSystem(system: IParticleSystem) {
+        const particleSystem = system as unknown as ParticleSystem;
+        particleSystem._renderer = this;
+
+        const settings = particleSystem.getRendererSettings();
+
+        for (let i = 0; i < this.batches.length; i++) {
+            if (BatchedRenderer.hasMatchingBatch(this.batches[i].settings, settings)) {
+                this.batches[i].addSystem(system);
+                this.systemToBatchIndex.set(system, i);
+
+                return;
+            }
+        }
+
+        const vfxBatch = this.createVFXBatchFromSettings(settings);
+        vfxBatch.addSystem(system);
+
+        if (this.depthTexture) {
+            vfxBatch.applyDepthTexture(this.depthTexture);
+        }
+
+        this.addVFXBatch(system, vfxBatch);
+    }
+
+    /**
+     * Deletes a particle system from its batch.
+     * @param {IParticleSystem} system - The particle system to delete.
+     */
+    deleteSystem(system: IParticleSystem) {
+        const batchIndex = this.systemToBatchIndex.get(system);
+        if (batchIndex === undefined) return;
+
+        this.batches[batchIndex].removeSystem(system);
+        this.systemToBatchIndex.delete(system);
+    }
+
+    /**
+     * Updates a particle system when the system has changed and requires reloading.
+     * @param {IParticleSystem} system - The particle system to update.
+     */
+    updateSystem(system: IParticleSystem) {
+        this.deleteSystem(system);
+        this.addSystem(system);
+    }
+
+    /**
+     * Updates all batches.
+     * @param {number} delta - The time delta for the update.
+     */
+    update(delta: number) {
+        for (const system of this.systemToBatchIndex.keys()) {
+            (system as any).update(delta);
+        }
+
+        for (let i = 0; i < this.batches.length; i++) {
+            this.batches[i].update();
+        }
+    }
+
+    /**
+     * Sets the depth texture for all batches. It will be used for soft particles.
+     * @param {Texture | null} depthTexture - The depth texture to set.
+     */
+    setDepthTexture(depthTexture: Texture | null) {
+        this.depthTexture = depthTexture;
+
+        for (const batch of this.batches) {
+            batch.applyDepthTexture(depthTexture);
+        }
+    }
+
+    private createVFXBatchFromSettings(settings: VFXBatchSettings): VFXBatch {
+        switch (settings.renderMode) {
+            case RenderMode.Trail:
+                return new TrailBatch(settings);
+            case RenderMode.Mesh:
+            case RenderMode.BillBoard:
+            case RenderMode.VerticalBillBoard:
+            case RenderMode.HorizontalBillBoard:
+            case RenderMode.StretchedBillBoard:
+                return new SpriteBatch(settings);
+            default:
+                settings.renderMode satisfies never;
+                throw new Error(`Unsupported render mode: ${settings.renderMode}`);
+        }
+    }
+
+    private addVFXBatch(system: IParticleSystem, batch: VFXBatch) {
+        this.batches.push(batch);
+        this.systemToBatchIndex.set(system, this.batches.length - 1);
+
+        this.add(batch);
+    }
+
+    private static hasMatchingBatch(a: StoredBatchSettings, b: VFXBatchSettings) {
         return (
             a.material.side === b.material.side &&
             a.material.blending === b.material.blending &&
@@ -127,93 +223,5 @@ export class BatchedRenderer extends Object3D {
             a.renderOrder === b.renderOrder &&
             a.layers.mask === b.layers.mask
         );
-    }
-
-    /**
-     * Adds a particle system to a batch.
-     * @param {IParticleSystem} system - The particle system to add.
-     */
-    addSystem(system: IParticleSystem) {
-        (system as unknown as ParticleSystem)._renderer = this;
-        const settings = (system as unknown as ParticleSystem).getRendererSettings();
-        for (let i = 0; i < this.batches.length; i++) {
-            if (BatchedRenderer.equals(this.batches[i].settings, settings)) {
-                this.batches[i].addSystem(system);
-                this.systemToBatchIndex.set(system, i);
-                return;
-            }
-        }
-        let batch;
-        switch (settings.renderMode) {
-            case RenderMode.Trail:
-                batch = new TrailBatch(settings);
-                break;
-            case RenderMode.Mesh:
-            case RenderMode.BillBoard:
-            case RenderMode.VerticalBillBoard:
-            case RenderMode.HorizontalBillBoard:
-            case RenderMode.StretchedBillBoard:
-                batch = new SpriteBatch(settings);
-                break;
-        }
-        if (this.depthTexture) {
-            batch.applyDepthTexture(this.depthTexture);
-        }
-        batch.addSystem(system);
-        this.batches.push(batch);
-        this.systemToBatchIndex.set(system, this.batches.length - 1);
-        this.add(batch);
-    }
-
-    /**
-     * Deletes a particle system from its batch.
-     * @param {IParticleSystem} system - The particle system to delete.
-     */
-    deleteSystem(system: IParticleSystem) {
-        const batchIndex = this.systemToBatchIndex.get(system);
-        if (batchIndex != undefined) {
-            this.batches[batchIndex].removeSystem(system);
-            this.systemToBatchIndex.delete(system);
-        }
-        /*const settings = system.getRendererSettings();
-        for (let i = 0; i < this.batches.length; i++) {
-            if (BatchedParticleRenderer.equals(this.batches[i].settings, settings)) {
-                this.batches[i].removeSystem(system);
-                return;
-            }
-        }*/
-    }
-
-    /**
-     * Sets the depth texture for all batches. it will be used for soft particles.
-     * @param {Texture | null} depthTexture - The depth texture to set.
-     */
-    setDepthTexture(depthTexture: Texture | null) {
-        this.depthTexture = depthTexture;
-        for (const batch of this.batches) {
-            batch.applyDepthTexture(depthTexture);
-        }
-    }
-
-    /**
-     * Updates a particle system when the particle system has changed requires reloading.
-     * @param {IParticleSystem} system - The particle system to update.
-     */
-    updateSystem(system: IParticleSystem) {
-        this.deleteSystem(system);
-        this.addSystem(system);
-    }
-
-    /**
-     * Updates all batches.
-     * @param {number} delta - The time delta for the update.
-     */
-    update(delta: number) {
-        this.systemToBatchIndex.forEach((value, ps) => {
-            (ps as any).update(delta);
-        });
-        for (let i = 0; i < this.batches.length; i++) {
-            this.batches[i].update();
-        }
     }
 }

--- a/packages/three.quarks/src/MeshSurfaceEmitter.ts
+++ b/packages/three.quarks/src/MeshSurfaceEmitter.ts
@@ -1,123 +1,59 @@
-import {Triangle, BufferGeometry} from 'three';
-import {Vector3} from 'three';
 import {
-    Particle,
     EmitterShape,
-    ShapeJSON,
-    JsonMetaData,
     IParticleSystem,
-    Vector3 as QuarksVector3,
+    JsonMetaData,
+    Particle,
     Plugin,
+    Vector3 as QuarksVector3,
+    ShapeJSON,
 } from 'quarks.core';
+import {BufferAttribute, BufferGeometry, Triangle, Vector3} from 'three';
 
 /**
  * A particle emitter that emits particles from the surface of a mesh uniformly.
  */
 export class MeshSurfaceEmitter implements EmitterShape {
-    type = 'mesh_surface';
+    readonly type = 'mesh_surface';
 
-    private _triangleIndexToArea: number[] = [];
+    private readonly _cumulativeTriangleAreas: number[] = [];
+    private readonly _vA: Vector3 = new Vector3();
+    private readonly _vB: Vector3 = new Vector3();
+    private readonly _vC: Vector3 = new Vector3();
+
     private _geometry?: BufferGeometry;
+
+    constructor(geometry?: BufferGeometry) {
+        if (!geometry) return;
+
+        this.geometry = geometry;
+    }
 
     get geometry() {
         return this._geometry;
     }
+
     set geometry(geometry: BufferGeometry | undefined) {
         this._geometry = geometry;
-        if (geometry === undefined) {
-            return;
-        }
-        if (typeof geometry === 'string') {
-            return;
-        }
-        // optimization
-        /*if (mesh.userData.triangleIndexToArea) {
-            this._triangleIndexToArea = mesh.userData.triangleIndexToArea;
-            return;
-        }*/
-        const tri = new Triangle();
-        this._triangleIndexToArea.length = 0;
-        let area = 0;
-        if (!geometry.getIndex()) {
-            return;
-        }
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const array = geometry.getIndex()!.array;
-        const triCount = array.length / 3;
-        this._triangleIndexToArea.push(0);
-        for (let i = 0; i < triCount; i++) {
-            tri.setFromAttributeAndIndices(
-                geometry.getAttribute('position'),
-                array[i * 3],
-                array[i * 3 + 1],
-                array[i * 3 + 2]
-            );
-            area += tri.getArea();
-            this._triangleIndexToArea.push(area);
-        }
-        geometry.userData.triangleIndexToArea = this._triangleIndexToArea;
+        if (geometry === undefined || typeof geometry === 'string') return;
+
+        this.rebuildCumulativeTriangleAreas(geometry);
     }
 
-    constructor(geometry?: BufferGeometry) {
-        if (!geometry) {
-            return;
-        }
-        this.geometry = geometry;
-    }
-
-    private _tempA: Vector3 = new Vector3();
-    private _tempB: Vector3 = new Vector3();
-    private _tempC: Vector3 = new Vector3();
-
-    initialize(p: Particle) {
+    initialize(particle: Particle) {
         const geometry = this._geometry;
-        if (!geometry || geometry.getIndex() === null) {
-            p.position.set(0, 0, 0);
-            p.velocity.set(0, 0, 1).multiplyScalar(p.startSpeed);
+        const indexBuffer = geometry?.getIndex();
+
+        if (!geometry || !indexBuffer) {
+            particle.position.set(0, 0, 0);
+            particle.velocity.set(0, 0, 1).multiplyScalar(particle.startSpeed);
+
             return;
         }
-        const triCount = this._triangleIndexToArea.length - 1;
-        let left = 0,
-            right = triCount;
-        const target = Math.random() * this._triangleIndexToArea[triCount];
-        while (left + 1 < right) {
-            const mid = Math.floor((left + right) / 2);
-            if (target < this._triangleIndexToArea[mid]) {
-                right = mid;
-            } else {
-                left = mid;
-            }
-        }
 
-        //const area = this._triangleIndexToArea[left + 1] - this._triangleIndexToArea[left];
-        //const percent = (target - this._triangleIndexToArea[left]) / area;
-        let u1 = Math.random();
-        let u2 = Math.random();
-        if (u1 + u2 > 1) {
-            u1 = 1 - u1;
-            u2 = 1 - u2;
-        }
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const index1 = geometry.getIndex()!.array[left * 3];
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const index2 = geometry.getIndex()!.array[left * 3 + 1];
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const index3 = geometry.getIndex()!.array[left * 3 + 2];
-        const positionBuffer = geometry.getAttribute('position');
-        this._tempA.fromBufferAttribute(positionBuffer, index1);
-        this._tempB.fromBufferAttribute(positionBuffer, index2);
-        this._tempC.fromBufferAttribute(positionBuffer, index3);
-        this._tempB.sub(this._tempA);
-        this._tempC.sub(this._tempA);
-        this._tempA.addScaledVector(this._tempB, u1).addScaledVector(this._tempC, u2);
-        p.position.copy(this._tempA as unknown as QuarksVector3);
-
-        // velocity based on tri normal
-        this._tempA.copy(this._tempB).cross(this._tempC).normalize();
-        p.velocity.copy(this._tempA as unknown as QuarksVector3).normalize().multiplyScalar(p.startSpeed);
-        /*p.position.applyMatrix4(this._mesh.matrixWorld);
-        p.velocity.applyMatrix3(this._mesh.normalMatrix);*/
+        this.initializeFromTriangle(particle, geometry, indexBuffer);
     }
+
+    update(system: IParticleSystem, delta: number): void {}
 
     toJSON(): ShapeJSON {
         return {
@@ -127,25 +63,104 @@ export class MeshSurfaceEmitter implements EmitterShape {
     }
 
     static fromJSON(json: any, meta: JsonMetaData): MeshSurfaceEmitter {
-        return new MeshSurfaceEmitter(meta.geometries[json.geometry] as BufferGeometry);
+        // Serialized shapes may use "geometry", while toJSON currently emits "mesh".
+        return new MeshSurfaceEmitter(meta.geometries[json.mesh ?? json.geometry] as BufferGeometry);
     }
 
     clone(): EmitterShape {
         return new MeshSurfaceEmitter(this._geometry);
     }
 
-    update(system: IParticleSystem, delta: number): void {}
+    private rebuildCumulativeTriangleAreas(geometry: BufferGeometry) {
+        this._cumulativeTriangleAreas.length = 0;
+
+        const indexBuffer = geometry.getIndex()?.array;
+        if (!indexBuffer) return;
+
+        this._cumulativeTriangleAreas.push(0);
+
+        const tri = new Triangle();
+        const triCount = indexBuffer.length / 3;
+
+        let area = 0;
+
+        for (let i = 0; i < triCount; i++) {
+            tri.setFromAttributeAndIndices(
+                geometry.getAttribute('position'),
+                indexBuffer[i * 3],
+                indexBuffer[i * 3 + 1],
+                indexBuffer[i * 3 + 2]
+            );
+
+            area += tri.getArea();
+            this._cumulativeTriangleAreas.push(area);
+        }
+
+        geometry.userData.triangleIndexToArea = this._cumulativeTriangleAreas;
+    }
+
+    private sampleTriangleIndex() {
+        const triangleCount = this._cumulativeTriangleAreas.length - 1;
+        const targetArea = Math.random() * this._cumulativeTriangleAreas[triangleCount];
+
+        let left = 0,
+            right = triangleCount;
+
+        while (left + 1 < right) {
+            const mid = Math.floor((left + right) / 2);
+
+            if (targetArea < this._cumulativeTriangleAreas[mid]) {
+                right = mid;
+            } else {
+                left = mid;
+            }
+        }
+
+        return left;
+    }
+
+    private initializeFromTriangle(particle: Particle, geometry: BufferGeometry, indexBuffer: BufferAttribute) {
+        let u1 = Math.random();
+        let u2 = Math.random();
+
+        if (u1 + u2 > 1) {
+            u1 = 1 - u1;
+            u2 = 1 - u2;
+        }
+
+        const positionBuffer = geometry.getAttribute('position');
+        const triangleIndex = this.sampleTriangleIndex();
+
+        this._vA.fromBufferAttribute(positionBuffer, indexBuffer.array[triangleIndex * 3]);
+        this._vB.fromBufferAttribute(positionBuffer, indexBuffer.array[triangleIndex * 3 + 1]);
+        this._vC.fromBufferAttribute(positionBuffer, indexBuffer.array[triangleIndex * 3 + 2]);
+
+        this._vB.sub(this._vA);
+        this._vC.sub(this._vA);
+        this._vA.addScaledVector(this._vB, u1).addScaledVector(this._vC, u2);
+
+        particle.position.copy(this._vA as unknown as QuarksVector3);
+
+        // Velocity based on triangle normal
+        this._vA.copy(this._vB).cross(this._vC).normalize();
+
+        particle.velocity
+            .copy(this._vA as unknown as QuarksVector3)
+            .normalize()
+            .multiplyScalar(particle.startSpeed);
+    }
 }
 
 export const MeshSurfaceEmitterPlugin: Plugin = {
-    id: "three.quarks",
+    id: 'three.quarks',
     initialize: () => {},
-    emitterShapes: [{
-
-        type: 'mesh_surface',
-        params: [['geometry', ['geometry']]],
-        constructor: MeshSurfaceEmitter,
-        loadJSON: MeshSurfaceEmitter.fromJSON,
-    }],
+    emitterShapes: [
+        {
+            type: 'mesh_surface',
+            params: [['geometry', ['geometry']]],
+            constructor: MeshSurfaceEmitter,
+            loadJSON: MeshSurfaceEmitter.fromJSON,
+        },
+    ],
     behaviors: [],
 };

--- a/packages/three.quarks/src/ParticleEmitter.ts
+++ b/packages/three.quarks/src/ParticleEmitter.ts
@@ -1,5 +1,5 @@
+import {IEmitter, IParticleSystem, SerializationOptions} from 'quarks.core';
 import {Object3D, Object3DEventMap} from 'three';
-import {IParticleSystem, IEmitter, SerializationOptions} from 'quarks.core';
 
 /**
  * Interface representing metadata used in Threejs object toJSON method.
@@ -16,15 +16,14 @@ export interface MetaData {
 }
 
 /**
- * Class representing a three.quarks particle emitter. particle emitter is a node in the three.js scene graph
- * every particle emitter only associates with a particle system.
- * particle system
- * @extends Object3D
- * @template E - Type of the event map.
+ * Three.js scene graph node for a quarks particle system.
+ *
+ * ParticleEmitter bridges the core particle system to Object3D so it can be
+ * transformed, cloned, serialized, and parented like a regular scene node.
  */
-export class ParticleEmitter<E extends Object3DEventMap = Object3DEventMap>extends Object3D<E> implements IEmitter {
-    type = 'ParticleEmitter';
-    system: IParticleSystem;
+export class ParticleEmitter<E extends Object3DEventMap = Object3DEventMap> extends Object3D<E> implements IEmitter {
+    readonly type = 'ParticleEmitter';
+    readonly system: IParticleSystem;
 
     /**
      * Creates an instance of ParticleEmitter.
@@ -41,8 +40,10 @@ export class ParticleEmitter<E extends Object3DEventMap = Object3DEventMap>exten
      */
     clone() {
         const system = this.system.clone();
-        (system.emitter as unknown as ParticleEmitter).copy(this, true);
-        return system.emitter as any;
+        const emitter = system.emitter as ParticleEmitter<E>;
+        emitter.copy(this, true);
+
+        return emitter as this;
     }
 
     /**
@@ -57,11 +58,13 @@ export class ParticleEmitter<E extends Object3DEventMap = Object3DEventMap>exten
      */
     extractFromCache(cache: any) {
         const values = [];
+
         for (const key in cache) {
             const data = cache[key];
             delete data.metadata;
             values.push(data);
         }
+
         return values;
     }
 
@@ -74,9 +77,14 @@ export class ParticleEmitter<E extends Object3DEventMap = Object3DEventMap>exten
     toJSON(meta?: MetaData, options: SerializationOptions = {}): any {
         const children = this.children;
         this.children = this.children.filter((child) => child.type !== 'ParticleSystemPreview');
+
         const data = super.toJSON(meta);
         this.children = children;
-        if (this.system !== null) (data.object as any).ps = this.system.toJSON(meta!, options);
+
+        if (this.system !== null) {
+            (data.object as any).ps = this.system.toJSON(meta!, options);
+        }
+
         return data;
     }
 }

--- a/packages/three.quarks/src/ParticleSystem.ts
+++ b/packages/three.quarks/src/ParticleSystem.ts
@@ -49,11 +49,11 @@ import {
     Texture,
 } from 'three';
 
-import {BatchedRenderer, VFXBatchSettings} from './BatchedRenderer';
+import {BatchedRenderer} from './BatchedRenderer';
 import {MetaData, ParticleEmitter} from './ParticleEmitter';
 import {RendererDefaults} from './util/RendererDefaults';
 import {ThreeMetaData} from './util/ThreeUtil';
-import {RenderMode} from './VFXBatch';
+import {RenderMode, type VFXBatchSettings} from './VFXBatch';
 
 export interface BurstParameters {
     time: number;

--- a/packages/three.quarks/src/ParticleSystem.ts
+++ b/packages/three.quarks/src/ParticleSystem.ts
@@ -674,6 +674,7 @@ export class ParticleSystem implements IParticleSystem {
         this.duration = parameters.duration ?? 1;
         this.looping = parameters.looping === undefined ? true : parameters.looping;
         this.prewarm = parameters.prewarm === undefined ? false : parameters.prewarm;
+        this.startTileIndex = parameters.startTileIndex || new ConstantValue(0);
         this.startLife = parameters.startLife ?? new ConstantValue(5);
         this.startSpeed = parameters.startSpeed ?? new ConstantValue(0);
         this.startRotation = parameters.startRotation ?? new ConstantValue(0);
@@ -686,59 +687,22 @@ export class ParticleSystem implements IParticleSystem {
         this.emitterShape = parameters.shape ?? new SphereEmitter();
         this.behaviors = parameters.behaviors ?? [];
         this.worldSpace = parameters.worldSpace ?? false;
-        this.rendererEmitterSettings = parameters.rendererEmitterSettings ?? {};
 
-        if (parameters.renderMode === RenderMode.StretchedBillBoard) {
-            const stretchedBillboardSettings = this.rendererEmitterSettings as StretchedBillBoardSettings;
-            if (parameters.speedFactor !== undefined) {
-                stretchedBillboardSettings.speedFactor = parameters.speedFactor;
-            }
-
-            stretchedBillboardSettings.speedFactor = stretchedBillboardSettings.speedFactor ?? 0;
-            stretchedBillboardSettings.lengthFactor = stretchedBillboardSettings.lengthFactor ?? 0;
-        }
-
-        this.rendererSettings = {
-            instancingGeometry: parameters.instancingGeometry ?? DEFAULT_GEOMETRY,
-            renderMode: parameters.renderMode ?? RenderMode.BillBoard,
-            renderOrder: parameters.renderOrder ?? 0,
-            material: parameters.material,
-            uTileCount: parameters.uTileCount ?? 1,
-            vTileCount: parameters.vTileCount ?? 1,
-            blendTiles: parameters.blendTiles ?? false,
-            softParticles: parameters.softParticles ?? false,
-            softNearFade: parameters.softNearFade ?? 0,
-            softFarFade: parameters.softFarFade ?? 0,
-            layers: parameters.layers ?? new Layers(),
-        };
-
-        this.neededToUpdateRender = true;
+        this.rendererEmitterSettings = this.createRendererEmitterSettings(parameters);
+        this.rendererSettings = this.createRendererSettings(parameters);
 
         this.particles = [];
-
-        this.startTileIndex = parameters.startTileIndex || new ConstantValue(0);
-        this.emitter = new ParticleEmitter(this);
-
-        this.paused = false;
         this.particleNum = 0;
 
-        this.emissionState = {
-            isBursting: false,
-            burstParticleIndex: 0,
-            burstParticleCount: 0,
-            burstIndex: 0,
-            burstWaveIndex: 0,
-            time: 0,
-            waitEmiting: 0,
-            travelDistance: 0,
-        };
+        this.emitter = new ParticleEmitter(this);
+        this.emissionState = this.createEmissionState();
+        this.startEmissionGenerators();
 
-        this.emissionBursts.forEach((burst) => burst.count.startGen(this.memory));
-        this.emissionOverDistance.startGen(this.memory);
-
+        this.paused = false;
         this.emitEnded = false;
         this.markForDestroy = false;
         this.prewarmed = false;
+        this.neededToUpdateRender = true;
     }
 
     /**
@@ -761,6 +725,55 @@ export class ParticleSystem implements IParticleSystem {
     stop() {
         this.restart();
         this.pause();
+    }
+
+    private createRendererEmitterSettings(parameters: ParticleSystemParameters): RendererEmitterSettings {
+        const rendererEmitterSettings = parameters.rendererEmitterSettings ?? {};
+
+        if (parameters.renderMode === RenderMode.StretchedBillBoard) {
+            const sbbSettings = rendererEmitterSettings as StretchedBillBoardSettings;
+            sbbSettings.speedFactor = parameters.speedFactor ?? sbbSettings.speedFactor ?? 0;
+            sbbSettings.lengthFactor = sbbSettings.lengthFactor ?? 0;
+        }
+
+        return rendererEmitterSettings;
+    }
+
+    private createRendererSettings(parameters: ParticleSystemParameters): VFXBatchSettings {
+        return {
+            instancingGeometry: parameters.instancingGeometry ?? DEFAULT_GEOMETRY,
+            renderMode: parameters.renderMode ?? RenderMode.BillBoard,
+            renderOrder: parameters.renderOrder ?? 0,
+            material: parameters.material,
+            uTileCount: parameters.uTileCount ?? 1,
+            vTileCount: parameters.vTileCount ?? 1,
+            blendTiles: parameters.blendTiles ?? false,
+            softParticles: parameters.softParticles ?? false,
+            softNearFade: parameters.softNearFade ?? 0,
+            softFarFade: parameters.softFarFade ?? 0,
+            layers: parameters.layers ?? new Layers(),
+        };
+    }
+
+    private createEmissionState(): EmissionState {
+        return {
+            isBursting: false,
+            burstParticleIndex: 0,
+            burstParticleCount: 0,
+            burstIndex: 0,
+            burstWaveIndex: 0,
+            time: 0,
+            waitEmiting: 0,
+            travelDistance: 0,
+        };
+    }
+
+    private startEmissionGenerators(): void {
+        for (const burst of this.emissionBursts) {
+            burst.count.startGen(this.memory);
+        }
+
+        this.emissionOverDistance.startGen(this.memory);
     }
 
     private needsRestartForRenderModeChange(previousRenderMode: RenderMode, renderMode: RenderMode): boolean {
@@ -974,8 +987,7 @@ export class ParticleSystem implements IParticleSystem {
         this.emitEnded = false;
         this.markForDestroy = false;
         this.prewarmed = false;
-        this.emissionBursts.forEach((burst) => burst.count.startGen(this.memory));
-        this.emissionOverDistance.startGen(this.memory);
+        this.startEmissionGenerators();
     }
 
     /**

--- a/packages/three.quarks/src/ParticleSystem.ts
+++ b/packages/three.quarks/src/ParticleSystem.ts
@@ -1024,16 +1024,28 @@ export class ParticleSystem implements IParticleSystem {
         this.memory.length = 0;
         this.paused = false;
         this.particleNum = 0;
-        this.emissionState.isBursting = false;
-        this.emissionState.burstIndex = 0;
-        this.emissionState.burstWaveIndex = 0;
-        this.emissionState.time = 0;
-        this.emissionState.waitEmiting = 0;
-        this.behaviors.forEach((behavior) => behavior.reset());
+        this.resetEmissionState();
+
+        for (const behavior of this.behaviors) {
+            behavior.reset();
+        }
+
         this.emitEnded = false;
         this.markForDestroy = false;
         this.prewarmed = false;
         this.startEmissionGenerators();
+    }
+
+    private resetEmissionState(): void {
+        this.emissionState.isBursting = false;
+        this.emissionState.burstIndex = 0;
+        this.emissionState.burstWaveIndex = 0;
+        this.emissionState.burstParticleIndex = 0;
+        this.emissionState.burstParticleCount = 0;
+        this.emissionState.time = 0;
+        this.emissionState.waitEmiting = 0;
+        this.emissionState.travelDistance = 0;
+        this.emissionState.previousWorldPos = undefined;
     }
 
     /**

--- a/packages/three.quarks/src/ParticleSystem.ts
+++ b/packages/three.quarks/src/ParticleSystem.ts
@@ -428,7 +428,7 @@ export class ParticleSystem implements IParticleSystem {
     private readonly _qA = new Quaternion();
     private readonly _normalMatrix = new Matrix3();
 
-    private listeners: {[event: string]: ((event: ParticleSystemEvent) => void)[]} = {};
+    private listeners: {[event: string]: Set<(event: ParticleSystemEvent) => void>} = {};
 
     /**
      * @internal
@@ -1391,8 +1391,8 @@ export class ParticleSystem implements IParticleSystem {
      * @param callback - Callback invoked when the event fires.
      */
     addEventListener(event: ParticleSystemEventType, callback: (event: ParticleSystemEvent) => void): void {
-        if (!this.listeners[event]) this.listeners[event] = [];
-        this.listeners[event].push(callback);
+        if (!this.listeners[event]) this.listeners[event] = new Set();
+        this.listeners[event].add(callback);
     }
 
     /**
@@ -1400,7 +1400,7 @@ export class ParticleSystem implements IParticleSystem {
      * @param event - Event type to clear.
      */
     removeAllEventListeners(event: ParticleSystemEventType): void {
-        if (this.listeners[event]) this.listeners[event] = [];
+        this.listeners[event]?.clear();
     }
 
     /**
@@ -1409,17 +1409,15 @@ export class ParticleSystem implements IParticleSystem {
      * @param callback - Callback to remove.
      */
     removeEventListener(event: ParticleSystemEventType, callback: (event: ParticleSystemEvent) => void): void {
-        if (this.listeners[event]) {
-            const index = this.listeners[event].indexOf(callback);
-
-            if (index !== -1) {
-                this.listeners[event].splice(index, 1);
-            }
-        }
+        this.listeners[event]?.delete(callback);
     }
 
     private fire(event: ParticleSystemEvent) {
-        this.listeners[event.type]?.forEach((callback) => callback(event));
+        if (this.listeners[event.type] === undefined) return;
+
+        for (const callback of this.listeners[event.type]) {
+            callback(event);
+        }
     }
 
     /**

--- a/packages/three.quarks/src/ParticleSystem.ts
+++ b/packages/three.quarks/src/ParticleSystem.ts
@@ -410,7 +410,8 @@ export class ParticleSystem implements IParticleSystem {
     behaviors: Behavior[];
 
     /**
-     * Mutable emission playback state shared with emitter shapes and sub-emitters.
+     * Default mutable emission playback state used by this particle system.
+     * Sub-emitter calls may pass alternate EmissionState instances to emit.
      * @type {EmissionState}
      */
     emissionState: EmissionState;
@@ -889,7 +890,7 @@ export class ParticleSystem implements IParticleSystem {
         particle.speedModifier = 1;
 
         this.startColor.startGen(particle.memory);
-        this.startColor.genColor(particle.memory, particle.startColor, this.emissionState.time);
+        this.startColor.genColor(particle.memory, particle.startColor, normalizedTime);
         particle.color.copy(particle.startColor);
 
         this.startSpeed.startGen(particle.memory);
@@ -1186,7 +1187,7 @@ export class ParticleSystem implements IParticleSystem {
             const burst = this.emissionBursts[emissionState.burstIndex];
 
             if (Math.random() < burst.probability) {
-                const count = burst.count.genValue(this.memory, this.time);
+                const count = burst.count.genValue(this.memory, emissionState.time);
                 emissionState.isBursting = true;
                 emissionState.burstParticleCount = count;
 

--- a/packages/three.quarks/src/ParticleSystem.ts
+++ b/packages/three.quarks/src/ParticleSystem.ts
@@ -1002,7 +1002,7 @@ export class ParticleSystem implements IParticleSystem {
             this.markForDestroy = true;
         }
 
-        this.fire({type: 'emitEnd', particleSystem: this});
+        this.fire('emitEnd');
     }
 
     /**
@@ -1013,7 +1013,7 @@ export class ParticleSystem implements IParticleSystem {
         this.emitter.removeFromParent();
         this.emitter.dispose();
 
-        this.fire({type: 'destroy', particleSystem: this});
+        this.fire('destroy');
     }
 
     /**
@@ -1042,14 +1042,13 @@ export class ParticleSystem implements IParticleSystem {
     private update(delta: number) {
         if (this.paused) return;
 
-        let currentParent: Object3D = this.emitter;
-
-        while (currentParent.parent) {
-            currentParent = currentParent.parent;
+        if (this.isEmitterDetached()) {
+            this.dispose();
+            return;
         }
 
-        if (currentParent.type !== 'Scene') {
-            this.dispose();
+        if (this.emitEnded && this.particleNum === 0) {
+            if (this.markForDestroy) this.dispose();
             return;
         }
 
@@ -1058,25 +1057,14 @@ export class ParticleSystem implements IParticleSystem {
             this.emitter.updateWorldMatrix(true, false);
         }
 
-        if (this.emitEnded && this.particleNum === 0) {
-            if (this.markForDestroy && this.emitter.parent) this.dispose();
-            return;
-        }
-
-        if (this.looping && this.prewarm && !this.prewarmed) {
-            this.prewarmed = true;
-            for (let i = 0; i < this.duration * PREWARM_FPS; i++) {
-                // Prewarm advances the simulation in fixed steps before the first rendered update.
-                this.update(1.0 / PREWARM_FPS);
-            }
-        }
+        this.prewarmIfNeeded();
 
         if (delta > 0.1) {
             delta = 0.1;
         }
 
         if (this.neededToUpdateRender) {
-            if (this._renderer) this._renderer.updateSystem(this);
+            this._renderer?.updateSystem(this);
             this.neededToUpdateRender = false;
         }
 
@@ -1097,26 +1085,21 @@ export class ParticleSystem implements IParticleSystem {
             }
         }
 
-        for (let i = 0; i < this.particleNum; i++) {
-            if (
-                (this.rendererEmitterSettings as TrailSettings).followLocalOrigin &&
-                (this.particles[i] as TrailParticle).localPosition
-            ) {
-                this.particles[i].position.copy((this.particles[i] as TrailParticle).localPosition!);
+        const followLocalOrigin = (this.rendererEmitterSettings as TrailSettings).followLocalOrigin;
 
-                if (this.particles[i].parentMatrix) {
-                    this.particles[i].position.applyMatrix4(this.particles[i].parentMatrix!);
-                } else {
-                    this.particles[i].position.applyMatrix4(this.emitter.matrixWorld as unknown as Matrix4);
-                }
+        for (let i = 0; i < this.particleNum; i++) {
+            const particle = this.particles[i];
+            const localPosition = (particle as TrailParticle).localPosition;
+
+            if (followLocalOrigin && localPosition) {
+                particle.position
+                    .copy(localPosition)
+                    .applyMatrix4(particle.parentMatrix ?? (this.emitter.matrixWorld as unknown as Matrix4));
             } else {
-                this.particles[i].position.addScaledVector(
-                    this.particles[i].velocity,
-                    delta * this.particles[i].speedModifier
-                );
+                particle.position.addScaledVector(particle.velocity, delta * particle.speedModifier);
             }
 
-            this.particles[i].age += delta;
+            particle.age += delta;
         }
 
         if (this.rendererSettings.renderMode === RenderMode.Trail) {
@@ -1129,15 +1112,40 @@ export class ParticleSystem implements IParticleSystem {
         // Particle died
         for (let i = 0; i < this.particleNum; i++) {
             const particle = this.particles[i];
+            const isTrailParticle = particle instanceof TrailParticle;
+            const hasFinishedTrail = !isTrailParticle || particle.previous.length === 0;
 
-            if (particle.died && (!(particle instanceof TrailParticle) || particle.previous.length === 0)) {
-                this.particles[i] = this.particles[this.particleNum - 1];
-                this.particles[this.particleNum - 1] = particle;
-                this.particleNum--;
-                i--;
-
-                this.fire({type: 'particleDied', particleSystem: this, particle: particle});
+            if (!particle.died || !hasFinishedTrail) {
+                continue;
             }
+
+            this.particles[i] = this.particles[this.particleNum - 1];
+            this.particles[this.particleNum - 1] = particle;
+            this.particleNum--;
+            i--;
+
+            this.fire('particleDied', particle);
+        }
+    }
+
+    private isEmitterDetached(): boolean {
+        let currentParent: Object3D = this.emitter;
+
+        while (currentParent.parent) {
+            currentParent = currentParent.parent;
+        }
+
+        return currentParent.type !== 'Scene';
+    }
+
+    private prewarmIfNeeded(): void {
+        if (!this.looping || !this.prewarm || this.prewarmed) return;
+
+        this.prewarmed = true;
+
+        for (let i = 0; i < this.duration * PREWARM_FPS; i++) {
+            // Prewarm advances the simulation in fixed steps before the first rendered update.
+            this.update(1.0 / PREWARM_FPS);
         }
     }
 
@@ -1432,10 +1440,16 @@ export class ParticleSystem implements IParticleSystem {
         this.listeners[event]?.delete(callback);
     }
 
-    private fire(event: ParticleSystemEvent) {
-        if (this.listeners[event.type] === undefined) return;
+    private fire(type: ParticleSystemEventType, particle?: Particle) {
+        const listeners = this.listeners[type];
+        if (!listeners || listeners.size === 0) return;
 
-        for (const callback of this.listeners[event.type]) {
+        const event: ParticleSystemEvent = {type, particleSystem: this};
+        if (particle !== undefined) {
+            event.particle = particle;
+        }
+
+        for (const callback of listeners) {
             callback(event);
         }
     }

--- a/packages/three.quarks/src/ParticleSystem.ts
+++ b/packages/three.quarks/src/ParticleSystem.ts
@@ -620,52 +620,20 @@ export class ParticleSystem implements IParticleSystem {
      * {@link RenderMode}
      */
     set renderMode(renderMode: RenderMode) {
-        if (this.rendererSettings.renderMode !== renderMode) {
-            let needRestart = false;
+        const previousRenderMode = this.rendererSettings.renderMode;
+        if (previousRenderMode === renderMode) return;
 
-            if (this.rendererSettings.renderMode === RenderMode.Trail) {
-                needRestart = true;
-            }
+        const shouldRestart = this.needsRestartForRenderModeChange(previousRenderMode, renderMode);
 
-            if (this.rendererSettings.renderMode === RenderMode.Mesh) {
-                this.startRotation = new ConstantValue(0);
-            }
+        this.applyRenderModeDefaults(previousRenderMode, renderMode);
+        this.rendererSettings.renderMode = renderMode;
 
-            switch (renderMode) {
-                case RenderMode.Trail:
-                    this.rendererEmitterSettings = {
-                        startLength: new ConstantValue(30),
-                        followLocalOrigin: false,
-                    };
-                    needRestart = true;
-                    break;
-                case RenderMode.Mesh:
-                    this.rendererEmitterSettings = {
-                        geometry: DEFAULT_GEOMETRY,
-                    };
-                    this.startRotation = new AxisAngleGenerator(new Vector3(0, 1, 0), new ConstantValue(0));
-                    break;
-                case RenderMode.StretchedBillBoard:
-                    this.rendererEmitterSettings = {speedFactor: 0, lengthFactor: 2};
-                    this.rendererSettings.instancingGeometry = DEFAULT_GEOMETRY;
-                    break;
-                case RenderMode.BillBoard:
-                case RenderMode.VerticalBillBoard:
-                case RenderMode.HorizontalBillBoard:
-                    this.rendererEmitterSettings = {};
-                    this.rendererSettings.instancingGeometry = DEFAULT_GEOMETRY;
-                    break;
-            }
-
-            this.rendererSettings.renderMode = renderMode;
-
-            if (needRestart) {
-                this.restart();
-                this.particles.length = 0;
-            }
-
-            this.neededToUpdateRender = true;
+        if (shouldRestart) {
+            this.restart();
+            this.particles.length = 0;
         }
+
+        this.neededToUpdateRender = true;
     }
 
     /**
@@ -793,6 +761,41 @@ export class ParticleSystem implements IParticleSystem {
     stop() {
         this.restart();
         this.pause();
+    }
+
+    private needsRestartForRenderModeChange(previousRenderMode: RenderMode, renderMode: RenderMode): boolean {
+        // Keep render-mode restart policy named even while it is simple so the setter
+        // does not become the dumping ground for future transition edge cases.
+        return previousRenderMode === RenderMode.Trail || renderMode === RenderMode.Trail;
+    }
+
+    private applyRenderModeDefaults(previousRenderMode: RenderMode, renderMode: RenderMode): void {
+        if (previousRenderMode === RenderMode.Mesh) {
+            this.startRotation = new ConstantValue(0);
+        }
+
+        switch (renderMode) {
+            case RenderMode.Trail:
+                this.rendererEmitterSettings = {
+                    startLength: new ConstantValue(30),
+                    followLocalOrigin: false,
+                };
+                break;
+            case RenderMode.Mesh:
+                this.rendererEmitterSettings = {geometry: DEFAULT_GEOMETRY};
+                this.startRotation = new AxisAngleGenerator(new Vector3(0, 1, 0), new ConstantValue(0));
+                break;
+            case RenderMode.StretchedBillBoard:
+                this.rendererEmitterSettings = {speedFactor: 0, lengthFactor: 2};
+                this.rendererSettings.instancingGeometry = DEFAULT_GEOMETRY;
+                break;
+            case RenderMode.BillBoard:
+            case RenderMode.VerticalBillBoard:
+            case RenderMode.HorizontalBillBoard:
+                this.rendererEmitterSettings = {};
+                this.rendererSettings.instancingGeometry = DEFAULT_GEOMETRY;
+                break;
+        }
     }
 
     private spawn(count: number, emissionState: EmissionState, matrix: Matrix4) {

--- a/packages/three.quarks/src/ParticleSystem.ts
+++ b/packages/three.quarks/src/ParticleSystem.ts
@@ -1,57 +1,61 @@
 import {
     AxisAngleGenerator,
+    Behavior,
+    BehaviorFromJSON,
     ColorGenerator,
     ColorGeneratorFromJSON,
     ConstantColor,
     ConstantValue,
+    EmissionState,
+    EmitterFromJSON,
+    EmitterShape,
     FunctionColorGenerator,
     FunctionJSON,
     FunctionValueGenerator,
     GeneratorFromJSON,
-    ValueGenerator,
-    ValueGeneratorFromJSON,
-    Behavior,
-    BehaviorFromJSON,
-    Particle,
-    SpriteParticle,
-    TrailParticle,
-    EmitterFromJSON,
-    EmitterShape,
-    ShapeJSON,
-    SphereEmitter,
-    RendererEmitterSettings,
-    RotationGenerator,
-    IParticleSystem,
-    EmissionState,
     GeneratorMemory,
-    TrailSettings, SerializationOptions, StretchedBillBoardSettings,
-    Vector3,
-    Vector4,
+    IParticleSystem,
     Matrix3,
     Matrix4,
+    Particle,
+    ParticleSystemEvent,
+    ParticleSystemEventType,
     Quaternion,
-    Vector3Generator, ParticleSystemEvent, ParticleSystemEventType,
+    RendererEmitterSettings,
+    RotationGenerator,
+    SerializationOptions,
+    ShapeJSON,
+    SphereEmitter,
+    SpriteParticle,
+    StretchedBillBoardSettings,
+    TrailParticle,
+    TrailSettings,
+    ValueGenerator,
+    ValueGeneratorFromJSON,
+    Vector3,
+    Vector3Generator,
+    Vector4,
 } from 'quarks.core';
-import {MetaData, ParticleEmitter} from './ParticleEmitter';
+
 import {
     AdditiveBlending,
-    Object3DEventMap,
     Blending,
     BufferGeometry,
     DoubleSide,
     Layers,
-    Object3D,
-    PlaneGeometry,
-    Texture,
     Material,
     MeshBasicMaterial,
+    Object3D,
+    Object3DEventMap,
+    PlaneGeometry,
+    Texture,
 } from 'three';
+
+import {BatchedRenderer, VFXBatchSettings} from './BatchedRenderer';
+import {MetaData, ParticleEmitter} from './ParticleEmitter';
+import {ThreeMetaData} from './util/ThreeUtil';
 import {RenderMode} from './VFXBatch';
-import {
-    BatchedRenderer,
-    VFXBatchSettings,
-} from './BatchedRenderer';
-import { ThreeMetaData } from './util/ThreeUtil';
+
 export interface BurstParameters {
     time: number;
     count: ValueGenerator | FunctionValueGenerator;
@@ -59,13 +63,6 @@ export interface BurstParameters {
     interval: number;
     probability: number;
 }
-
-const UP = new Vector3(0, 0, 1);
-const tempQ = new Quaternion();
-const tempV = new Vector3();
-const tempV2 = new Vector3();
-const tempV3 = new Vector3();
-const PREWARM_FPS = 60;
 
 /**
  * Interface representing the JSON parameters for a burst.
@@ -113,7 +110,6 @@ export interface ParticleSystemParameters {
      * The duration of the particle system.
      */
     duration?: number;
-
     /**
      * The shape of the emitter.
      */
@@ -135,7 +131,8 @@ export interface ParticleSystemParameters {
      */
     startSize?: ValueGenerator | FunctionValueGenerator | Vector3Generator;
     /**
-     * The initial length of particles.
+     * Legacy trail length shortcut retained for parameter compatibility.
+     * Trail systems read rendererEmitterSettings.startLength.
      */
     startLength?: ValueGenerator | FunctionValueGenerator;
     /**
@@ -153,17 +150,15 @@ export interface ParticleSystemParameters {
     /**
      * The burst parameters for emission.
      */
-    emissionBursts?: Array<BurstParameters>;
+    emissionBursts?: BurstParameters[];
     /**
      * Whether the particle system is only used by others.
      */
     onlyUsedByOther?: boolean;
-
     /**
      * The behaviors of the particle system.
      */
-    behaviors?: Array<Behavior>;
-
+    behaviors?: Behavior[];
     /**
      * The instancing geometry of the particle system.
      */
@@ -220,7 +215,6 @@ export interface ParticleSystemParameters {
      * The render order of the particle system.
      */
     renderOrder?: number;
-
     /**
      * Whether the particle system uses world space.
      */
@@ -229,12 +223,10 @@ export interface ParticleSystemParameters {
 
 export interface ParticleSystemJSONParameters {
     version: string;
-    // parameters
     autoDestroy: boolean;
     looping: boolean;
     prewarm: boolean;
     duration: number;
-
     shape: ShapeJSON;
     startLife: FunctionJSON;
     startSpeed: FunctionJSON;
@@ -243,16 +235,14 @@ export interface ParticleSystemJSONParameters {
     startColor: FunctionJSON;
     emissionOverTime: FunctionJSON;
     emissionOverDistance: FunctionJSON;
-    emissionBursts?: Array<BurstParametersJSON>;
+    emissionBursts?: BurstParametersJSON[];
     onlyUsedByOther: boolean;
-
     rendererEmitterSettings: RendererEmitterSettings;
-
     instancingGeometry?: any;
     renderMode: number;
     renderOrder?: number;
     speedFactor?: number;
-    texture?: string; // deprecated
+    texture?: string; // Deprecated
     material: string;
     layers?: number;
     startTileIndex: FunctionJSON | number;
@@ -262,221 +252,207 @@ export interface ParticleSystemJSONParameters {
     softParticles?: boolean;
     softFarFade?: number;
     softNearFade?: number;
-    blending?: Blending; // deprecated
-    transparent?: boolean; // deprecated
-
-    behaviors: Array<any>;
-
+    blending?: Blending; // Deprecated
+    transparent?: boolean; // Deprecated
+    behaviors: any[];
     worldSpace: boolean;
 }
 
+const PREWARM_FPS = 60;
 const DEFAULT_GEOMETRY = new PlaneGeometry(1, 1, 1, 1);
+const UP = new Vector3(0, 0, 1);
 
 /**
- * ParticleSystem represents a system that generates and controls particles with similar attributes.
- *
+ * Runtime particle system that owns emission state, particles, behaviors, and renderer settings for one emitter.
  * @class
  */
 export class ParticleSystem implements IParticleSystem {
     /**
-     * whether the ParticleSystem should be automatically disposed when it finishes emitting particles.
-     *
+     * Whether the ParticleSystem should be automatically disposed when it finishes emitting particles.
      * @type {boolean}
      */
     autoDestroy: boolean;
 
     /**
-     * Determines whether a looping ParticleSystem should prewarm, i.e., the Particle System looks like it has already simulated for one loop when first becoming visible.
-     *
+     * Determines whether a looping ParticleSystem should prewarm, i.e. simulate one loop before first becoming visible.
      * @type {boolean}
      */
     prewarm: boolean;
 
     /**
      * Determines whether the ParticleSystem should loop, i.e., restart emitting particles after the duration of the particle system is expired.
-     *
      * @type {boolean}
      */
     looping: boolean;
 
     /**
      * The duration of the ParticleSystem in seconds.
-     *
      * @type {number}
      */
     duration: number;
 
     /**
      * The value generator or function value generator for the starting life of particles.
-     *
      * @type {ValueGenerator | FunctionValueGenerator}
      */
     startLife: ValueGenerator | FunctionValueGenerator;
 
     /**
      * The value generator or function value generator for the starting speed of particles.
-     *
      * @type {ValueGenerator | FunctionValueGenerator}
      */
     startSpeed: ValueGenerator | FunctionValueGenerator;
 
     /**
      * The value generator or function value generator or rotation generator for the starting rotation of particles.
-     *
      * @type {ValueGenerator | FunctionValueGenerator | RotationGenerator}
      */
     startRotation: ValueGenerator | FunctionValueGenerator | RotationGenerator;
 
     /**
-     * The value generator or function value generator for the starting size of particles.
-     *
-     * @type {ValueGenerator | FunctionValueGenerator}
+     * The value generator, function value generator, or vector generator for the starting size of particles.
+     * @type {ValueGenerator | FunctionValueGenerator | Vector3Generator}
      */
     startSize: ValueGenerator | FunctionValueGenerator | Vector3Generator;
 
     /**
      * The color generator or function color generator for the starting color of particles.
-     *
      * @type {ColorGenerator | FunctionColorGenerator}
      */
     startColor: ColorGenerator | FunctionColorGenerator;
 
     /**
      * The value generator for the starting tile index of particles.
-     *
      * @type {ValueGenerator}
      */
     startTileIndex: ValueGenerator;
 
     /**
-     * The renderer emitter settings for the ParticleSystem.
-     *
-     * @type {TrailSettings | MeshSettings | BillBoardSettings | StretchedBillBoardSettings}
+     * Render-mode specific emitter settings for the ParticleSystem.
+     * @type {RendererEmitterSettings}
      */
     rendererEmitterSettings: RendererEmitterSettings;
 
     /**
      * The value generator or function value generator for the emission rate of particles over time.
-     *
      * @type {ValueGenerator | FunctionValueGenerator}
      */
     emissionOverTime: ValueGenerator | FunctionValueGenerator;
 
     /**
      * The value generator or function value generator for the emission rate of particles over distance.
-     *
      * @type {ValueGenerator | FunctionValueGenerator}
      */
     emissionOverDistance: ValueGenerator | FunctionValueGenerator;
 
     /**
      * An array of burst parameters for the ParticleSystem.
-     *
-     * @type {Array<BurstParameters>}
+     * @type {BurstParameters[]}
      */
-    emissionBursts: Array<BurstParameters>;
+    emissionBursts: BurstParameters[];
 
     /**
      * Determines whether the ParticleSystem is only used by other ParticleSystems.
-     *
      * @type {boolean}
      */
     onlyUsedByOther: boolean;
 
     /**
      * Determines whether the ParticleSystem is in world space or local space.
-     *
      * @type {boolean}
      */
     worldSpace: boolean;
 
     /**
      * The number of particles in the ParticleSystem.
-     *
      * @type {number}
      */
     particleNum: number;
 
     /**
      * Determines whether the ParticleSystem is paused.
-     *
      * @type {boolean}
      */
     paused: boolean;
 
     /**
      * All the particles in the ParticleSystem.
-     *
-     * @type {Array<Particle>}
+     * @type {Particle[]}
      */
-    particles: Array<Particle>;
+    particles: Particle[];
 
     /**
-     * the shape of the emitter.
-     *
+     * The shape of the emitter.
      * @type {EmitterShape}
      */
     emitterShape: EmitterShape;
 
     /**
-     * the emitter object that should be added in the scene.
-     *
+     * The emitter object that should be added to the scene.
      * @type {ParticleEmitter<Object3DEventMap>}
      */
     emitter: ParticleEmitter<Object3DEventMap>;
+
     /**
-     * the VFX renderer settings for the batch renderer
-     *
+     * The VFX renderer settings for the batch renderer.
      * @type {VFXBatchSettings}
      */
     rendererSettings: VFXBatchSettings;
 
     /**
-     * whether needs to update renderer settings for the batch renderer
-     *
+     * Whether the batch renderer needs to refresh this system's renderer settings.
      * @type {boolean}
      */
     neededToUpdateRender: boolean;
 
     /**
-     * a list of particle behaviors in the particle system
-     *
-     * @type {Array<Behavior>}
+     * The particle system behaviors.
+     * @type {Behavior[]}
      */
-    behaviors: Array<Behavior>;
+    behaviors: Behavior[];
 
+    /**
+     * Mutable emission playback state shared with emitter shapes and sub-emitters.
+     * @type {EmissionState}
+     */
     emissionState: EmissionState;
+
+    private memory: GeneratorMemory = [];
     private prewarmed: boolean;
     private emitEnded: boolean;
     private markForDestroy: boolean;
-    private previousWorldPos?: Vector3;
-    private temp: Vector3 = new Vector3();
-    private travelDistance = 0;
+    private firstTimeUpdate = true;
 
-    private normalMatrix: Matrix3 = new Matrix3();
-    private memory: GeneratorMemory = [];
-    private listeners: {[event: string]: Array<(event: ParticleSystemEvent)=>void>} = {};
-    /** @internal **/
+    private readonly _vA = new Vector3();
+    private readonly _vB = new Vector3();
+    private readonly _qA = new Quaternion();
+    private readonly _normalMatrix = new Matrix3();
+
+    private listeners: {[event: string]: ((event: ParticleSystemEvent) => void)[]} = {};
+
+    /**
+     * @internal
+     */
     _renderer?: BatchedRenderer;
 
     /**
-     * set the time of the playback of the particle system
-     * @param time
+     * Set the playback time of the particle system.
+     * @param time - Playback time in seconds.
      */
     set time(time: number) {
         this.emissionState.time = time;
     }
 
     /**
-     * get the current time of the playback of the particle system
+     * Get the current playback time of the particle system.
      */
     get time(): number {
         return this.emissionState.time;
     }
 
     /**
-     * layers control visibility of the object.
-     * currently if you change the layers setting, you need manually set this.neededToUpdateRender = true;
+     * Layers used by the renderer batch.
+     * Mutating the returned Layers object does not automatically mark renderer settings dirty.
      * @type {Layers}
      * @see {@link https://threejs.org/docs/index.html#api/en/core/Layers | Official Documentation}
      * @see {@link https://github.com/mrdoob/three.js/blob/master/src/core/Layers.js | Source}
@@ -486,32 +462,29 @@ export class ParticleSystem implements IParticleSystem {
     }
 
     /**
-     * get the texture of the particle system
+     * Get the texture map of the particle system material.
      */
     get texture() {
         return (this.rendererSettings.material as any).map;
     }
 
     /**
-     * Set the texture of the particle system
-     * It will rebuild the material
+     * Set the texture map of the particle system material and mark renderer settings dirty.
      */
     set texture(texture: Texture | null) {
         (this.rendererSettings.material as any).map = texture;
         this.neededToUpdateRender = true;
-        //this.emitter.material.uniforms.map.value = texture;
     }
 
     /**
-     * Get the material of the particle system
+     * Get the material used by the particle system.
      */
     get material() {
         return this.rendererSettings.material;
     }
 
     /**
-     * Set the material of the particle system
-     * It will rebuild the material
+     * Set the material used by the particle system and mark renderer settings dirty.
      */
     set material(material: Material) {
         this.rendererSettings.material = material;
@@ -519,15 +492,15 @@ export class ParticleSystem implements IParticleSystem {
     }
 
     /**
-     * Get the number of horizontal tiles in the texture.
+     * Get the horizontal tile count for the texture atlas.
      */
     get uTileCount() {
         return this.rendererSettings.uTileCount;
     }
 
     /**
-     * Set the number of horizontal tiles in the texture.
-     * @param u
+     * Set the horizontal tile count for the texture atlas.
+     * @param u - Horizontal tile count.
      */
     set uTileCount(u: number) {
         this.rendererSettings.uTileCount = u;
@@ -535,15 +508,15 @@ export class ParticleSystem implements IParticleSystem {
     }
 
     /**
-     * Get the number of vertical tiles in the texture.
+     * Get the vertical tile count for the texture atlas.
      */
     get vTileCount() {
         return this.rendererSettings.vTileCount;
     }
 
     /**
-     * Set the number of vertical tiles in the texture.
-     * @param v
+     * Set the vertical tile count for the texture atlas.
+     * @param v - Vertical tile count.
      */
     set vTileCount(v: number) {
         this.rendererSettings.vTileCount = v;
@@ -551,15 +524,15 @@ export class ParticleSystem implements IParticleSystem {
     }
 
     /**
-     * get whether the particle texture blends tile transitions
+     * Get whether the particle texture blends tile transitions.
      */
     get blendTiles() {
         return this.rendererSettings.blendTiles;
     }
 
     /**
-     * Set whether the particle texture blends tile transitions
-     * @param v
+     * Set whether the particle texture blends tile transitions.
+     * @param v - Whether tile transitions should blend.
      */
     set blendTiles(v: boolean) {
         this.rendererSettings.blendTiles = v;
@@ -576,27 +549,41 @@ export class ParticleSystem implements IParticleSystem {
 
     /**
      * Set whether the particle system uses soft particles.
-     * Soft particles are particles that fade out when they are close to geometry.
-     * @param v
+     * Soft particles fade out when they are close to geometry.
+     * @param v - Whether soft particles should be enabled.
      */
     set softParticles(v: boolean) {
         this.rendererSettings.softParticles = v;
         this.neededToUpdateRender = true;
     }
 
+    /**
+     * Get the near fade distance used by soft particles.
+     */
     get softNearFade() {
         return this.rendererSettings.softNearFade;
     }
 
+    /**
+     * Set the near fade distance used by soft particles.
+     * @param v - Near fade distance.
+     */
     set softNearFade(v: number) {
         this.rendererSettings.softNearFade = v;
         this.neededToUpdateRender = true;
     }
 
+    /**
+     * Get the far fade distance used by soft particles.
+     */
     get softFarFade() {
         return this.rendererSettings.softFarFade;
     }
 
+    /**
+     * Set the far fade distance used by soft particles.
+     * @param v - Far fade distance.
+     */
     set softFarFade(v: number) {
         this.rendererSettings.softFarFade = v;
         this.neededToUpdateRender = true;
@@ -604,15 +591,14 @@ export class ParticleSystem implements IParticleSystem {
 
     /**
      * Get the instancing geometry of the particle system.
-     * @param geometry
      */
     get instancingGeometry(): BufferGeometry {
         return this.rendererSettings.instancingGeometry;
     }
 
     /**
-     * Set the instancing geometry of the particle system.
-     * @param geometry
+     * Set the instancing geometry of the particle system and restart active particles.
+     * @param geometry - Instancing geometry used by the renderer batch.
      */
     set instancingGeometry(geometry: BufferGeometry) {
         this.restart();
@@ -630,18 +616,21 @@ export class ParticleSystem implements IParticleSystem {
     }
 
     /**
-     * Set the render mode of the particle system.
+     * Set the render mode of the particle system and reset render-mode specific emitter settings.
      * {@link RenderMode}
      */
     set renderMode(renderMode: RenderMode) {
         if (this.rendererSettings.renderMode !== renderMode) {
             let needRestart = false;
+
             if (this.rendererSettings.renderMode === RenderMode.Trail) {
                 needRestart = true;
             }
+
             if (this.rendererSettings.renderMode === RenderMode.Mesh) {
                 this.startRotation = new ConstantValue(0);
             }
+
             switch (renderMode) {
                 case RenderMode.Trail:
                     this.rendererEmitterSettings = {
@@ -667,36 +656,36 @@ export class ParticleSystem implements IParticleSystem {
                     this.rendererSettings.instancingGeometry = DEFAULT_GEOMETRY;
                     break;
             }
+
             this.rendererSettings.renderMode = renderMode;
+
             if (needRestart) {
                 this.restart();
                 this.particles.length = 0;
             }
+
             this.neededToUpdateRender = true;
         }
-        //this.emitter.rebuildMaterial();
     }
 
     /**
-     * get the render order of the particle system in render pipeline.
-     * the higher the value, the later the particle system is rendered.
+     * Get the render order of the particle system in the render pipeline.
      */
     get renderOrder(): number {
         return this.rendererSettings.renderOrder;
     }
 
     /**
-     * set the render order of the particle system in render pipeline.
-     * the higher the value, the later the particle system is rendered.
+     * Set the render order of the particle system in the render pipeline.
+     * Higher values are rendered later.
      */
     set renderOrder(renderOrder: number) {
         this.rendererSettings.renderOrder = renderOrder;
         this.neededToUpdateRender = true;
-        //this.emitter.rebuildMaterial();
     }
 
     /**
-     * get which blending to use.
+     * Get which blending mode to use.
      * @default THREE.NormalBlending
      */
     get blending() {
@@ -704,10 +693,10 @@ export class ParticleSystem implements IParticleSystem {
     }
 
     /**
-     * Set which blending to use.
+     * Set which blending mode to use.
      * @default THREE.NormalBlending
      */
-    set blending(blending) {
+    set blending(blending: Blending) {
         this.rendererSettings.material.blending = blending;
         this.neededToUpdateRender = true;
     }
@@ -722,20 +711,21 @@ export class ParticleSystem implements IParticleSystem {
         this.startRotation = parameters.startRotation ?? new ConstantValue(0);
         this.startSize = parameters.startSize ?? new ConstantValue(1);
         this.startColor = parameters.startColor ?? new ConstantColor(new Vector4(1, 1, 1, 1));
-        //this.startLength = parameters.startLength ?? new ConstantValue(30);
         this.emissionOverTime = parameters.emissionOverTime ?? new ConstantValue(10);
         this.emissionOverDistance = parameters.emissionOverDistance ?? new ConstantValue(0);
         this.emissionBursts = parameters.emissionBursts ?? [];
         this.onlyUsedByOther = parameters.onlyUsedByOther ?? false;
         this.emitterShape = parameters.shape ?? new SphereEmitter();
-        this.behaviors = parameters.behaviors ?? new Array<Behavior>();
+        this.behaviors = parameters.behaviors ?? [];
         this.worldSpace = parameters.worldSpace ?? false;
         this.rendererEmitterSettings = parameters.rendererEmitterSettings ?? {};
+
         if (parameters.renderMode === RenderMode.StretchedBillBoard) {
             const stretchedBillboardSettings = this.rendererEmitterSettings as StretchedBillBoardSettings;
             if (parameters.speedFactor !== undefined) {
                 stretchedBillboardSettings.speedFactor = parameters.speedFactor;
             }
+
             stretchedBillboardSettings.speedFactor = stretchedBillboardSettings.speedFactor ?? 0;
             stretchedBillboardSettings.lengthFactor = stretchedBillboardSettings.lengthFactor ?? 0;
         }
@@ -753,15 +743,17 @@ export class ParticleSystem implements IParticleSystem {
             softFarFade: parameters.softFarFade ?? 0,
             layers: parameters.layers ?? new Layers(),
         };
+
         this.neededToUpdateRender = true;
 
-        this.particles = new Array<Particle>();
+        this.particles = [];
 
         this.startTileIndex = parameters.startTileIndex || new ConstantValue(0);
         this.emitter = new ParticleEmitter(this);
 
         this.paused = false;
         this.particleNum = 0;
+
         this.emissionState = {
             isBursting: false,
             burstParticleIndex: 0,
@@ -782,22 +774,21 @@ export class ParticleSystem implements IParticleSystem {
     }
 
     /**
-     * Pause the simulation of the particle system
+     * Pause the particle system simulation.
      */
     pause() {
         this.paused = true;
     }
 
     /**
-     * Unpause the simulation of the particle system
+     * Resume the particle system simulation.
      */
     play() {
         this.paused = false;
     }
 
     /**
-     * remove all existing particles, reset the particle system
-     * and pause at the beginning
+     * Remove all existing particles, reset the particle system, and pause at the beginning.
      */
     stop() {
         this.restart();
@@ -805,14 +796,18 @@ export class ParticleSystem implements IParticleSystem {
     }
 
     private spawn(count: number, emissionState: EmissionState, matrix: Matrix4) {
-        tempQ.setFromRotationMatrix(matrix as unknown as Matrix4);
-        const translation = tempV;
-        const quaternion = tempQ;
-        const scale = tempV2;
+        this._qA.setFromRotationMatrix(matrix as unknown as Matrix4);
+
+        const translation = this._vA;
+        const quaternion = this._qA;
+        const scale = this._vB;
+
         matrix.decompose(translation, quaternion, scale);
+
         for (let i = 0; i < count; i++) {
             emissionState.burstParticleIndex = i;
             this.particleNum++;
+
             while (this.particles.length < this.particleNum) {
                 if (this.rendererSettings.renderMode === RenderMode.Trail) {
                     this.particles.push(new TrailParticle());
@@ -820,27 +815,42 @@ export class ParticleSystem implements IParticleSystem {
                     this.particles.push(new SpriteParticle());
                 }
             }
+
             const particle = this.particles[this.particleNum - 1];
             particle.reset();
             particle.speedModifier = 1;
+
             this.startColor.startGen(particle.memory);
             this.startColor.genColor(particle.memory, particle.startColor, this.emissionState.time);
             particle.color.copy(particle.startColor);
+
             this.startSpeed.startGen(particle.memory);
             particle.startSpeed = this.startSpeed.genValue(particle.memory, emissionState.time / this.duration);
+
             this.startLife.startGen(particle.memory);
             particle.life = this.startLife.genValue(particle.memory, emissionState.time / this.duration);
             particle.age = 0;
+
             this.startSize.startGen(particle.memory);
-            if (this.startSize.type === "vec3function") {
-                (this.startSize as Vector3Generator).genValue(particle.memory, particle.startSize, emissionState.time / this.duration);
+
+            if (this.startSize.type === 'vec3function') {
+                (this.startSize as Vector3Generator).genValue(
+                    particle.memory,
+                    particle.startSize,
+                    emissionState.time / this.duration
+                );
             } else {
-                const size = (this.startSize as FunctionValueGenerator).genValue(particle.memory, emissionState.time / this.duration);
+                const size = (this.startSize as FunctionValueGenerator).genValue(
+                    particle.memory,
+                    emissionState.time / this.duration
+                );
                 particle.startSize.set(size, size, size);
             }
+
             this.startTileIndex.startGen(particle.memory);
             particle.uvTile = this.startTileIndex.genValue(particle.memory);
             particle.size.copy(particle.startSize);
+
             if (
                 this.rendererSettings.renderMode === RenderMode.Mesh ||
                 this.rendererSettings.renderMode === RenderMode.BillBoard ||
@@ -850,21 +860,23 @@ export class ParticleSystem implements IParticleSystem {
             ) {
                 const sprite = particle as SpriteParticle;
                 this.startRotation.startGen(particle.memory);
+
                 if (this.rendererSettings.renderMode === RenderMode.Mesh) {
                     if (!(sprite.rotation instanceof Quaternion)) {
                         sprite.rotation = new Quaternion();
                     }
+
                     if (this.startRotation.type === 'rotation') {
                         this.startRotation.genValue(
                             particle.memory,
                             sprite.rotation as Quaternion,
                             1,
-                            emissionState.time / this.duration,
+                            emissionState.time / this.duration
                         );
                     } else {
                         (sprite.rotation as Quaternion).setFromAxisAngle(
                             UP,
-                            this.startRotation.genValue(sprite.memory, (emissionState.time / this.duration) as number),
+                            this.startRotation.genValue(sprite.memory, (emissionState.time / this.duration) as number)
                         );
                     }
                 } else {
@@ -873,20 +885,22 @@ export class ParticleSystem implements IParticleSystem {
                     } else {
                         sprite.rotation = this.startRotation.genValue(
                             sprite.memory,
-                            emissionState.time / this.duration,
+                            emissionState.time / this.duration
                         );
                     }
                 }
             } else if (this.rendererSettings.renderMode === RenderMode.Trail) {
                 const trail = particle as TrailParticle;
+
                 (this.rendererEmitterSettings as TrailSettings).startLength.startGen(trail.memory);
                 trail.length = (this.rendererEmitterSettings as TrailSettings).startLength.genValue(
                     trail.memory,
-                    emissionState.time / this.duration,
+                    emissionState.time / this.duration
                 );
             }
 
             this.emitterShape.initialize(particle, emissionState);
+
             if (
                 this.rendererSettings.renderMode === RenderMode.Trail &&
                 (this.rendererEmitterSettings as TrailSettings).followLocalOrigin
@@ -894,13 +908,15 @@ export class ParticleSystem implements IParticleSystem {
                 const trail = particle as TrailParticle;
                 trail.localPosition = new Vector3().copy(trail.position);
             }
+
             if (this.worldSpace) {
                 particle.position.applyMatrix4(matrix);
                 particle.startSize.multiply(scale).abs();
                 particle.size.copy(particle.startSize);
-                particle.velocity.multiply(scale).applyMatrix3(this.normalMatrix);
+                particle.velocity.multiply(scale).applyMatrix3(this._normalMatrix);
+
                 if (particle.rotation && particle.rotation instanceof Quaternion) {
-                    particle.rotation.multiplyQuaternions(tempQ, particle.rotation);
+                    particle.rotation.multiplyQuaternions(this._qA, particle.rotation);
                 }
             } else {
                 if (this.onlyUsedByOther) {
@@ -915,29 +931,32 @@ export class ParticleSystem implements IParticleSystem {
     }
 
     /**
-     * Stops emitting particles
+     * Stop emitting new particles.
      */
     endEmit() {
         this.emitEnded = true;
+
         if (this.autoDestroy) {
             this.markForDestroy = true;
         }
-        this.fire({type: "emitEnd", particleSystem: this});
+
+        this.fire({type: 'emitEnd', particleSystem: this});
     }
 
     /**
-     * remove the particle system's emitter from the scene
+     * Remove the particle system's emitter from the scene and release emitter resources.
      */
     dispose() {
         if (this._renderer) this._renderer.deleteSystem(this);
+
+        this.emitter.removeFromParent();
         this.emitter.dispose();
-        if (this.emitter.parent) this.emitter.parent.remove(this.emitter);
-        this.fire({type: "destroy", particleSystem: this});
+
+        this.fire({type: 'destroy', particleSystem: this});
     }
 
     /**
-     * remove all existing particles, reset the particle system
-     * and restart the particle system
+     * Remove all existing particles and restart the particle system.
      */
     restart() {
         this.memory.length = 0;
@@ -948,35 +967,32 @@ export class ParticleSystem implements IParticleSystem {
         this.emissionState.burstWaveIndex = 0;
         this.emissionState.time = 0;
         this.emissionState.waitEmiting = 0;
-        this.behaviors.forEach((behavior) => {
-            behavior.reset();
-        });
+        this.behaviors.forEach((behavior) => behavior.reset());
         this.emitEnded = false;
         this.markForDestroy = false;
         this.prewarmed = false;
-
         this.emissionBursts.forEach((burst) => burst.count.startGen(this.memory));
         this.emissionOverDistance.startGen(this.memory);
     }
 
-    private firstTimeUpdate = true;
-
     /**
-     * Update the particle system per frame
-     * @param delta
-     * @private
+     * Update the particle system for one frame.
+     * @param delta - Frame duration in seconds.
      */
     private update(delta: number) {
         if (this.paused) return;
 
         let currentParent: Object3D = this.emitter;
+
         while (currentParent.parent) {
             currentParent = currentParent.parent;
         }
+
         if (currentParent.type !== 'Scene') {
             this.dispose();
             return;
         }
+
         if (this.firstTimeUpdate) {
             this.firstTimeUpdate = false;
             this.emitter.updateWorldMatrix(true, false);
@@ -990,7 +1006,7 @@ export class ParticleSystem implements IParticleSystem {
         if (this.looping && this.prewarm && !this.prewarmed) {
             this.prewarmed = true;
             for (let i = 0; i < this.duration * PREWARM_FPS; i++) {
-                // stack overflow?
+                // Prewarm advances the simulation in fixed steps before the first rendered update.
                 this.update(1.0 / PREWARM_FPS);
             }
         }
@@ -1008,8 +1024,9 @@ export class ParticleSystem implements IParticleSystem {
             this.emit(delta, this.emissionState, this.emitter.matrixWorld as unknown as Matrix4);
         }
 
-        // simulate
+        // Simulate
         this.emitterShape.update(this, delta);
+
         for (let j = 0; j < this.behaviors.length; j++) {
             this.behaviors[j].frameUpdate(delta);
             for (let i = 0; i < this.particleNum; i++) {
@@ -1018,15 +1035,15 @@ export class ParticleSystem implements IParticleSystem {
                 }
             }
         }
+
         for (let i = 0; i < this.particleNum; i++) {
             if (
                 (this.rendererEmitterSettings as TrailSettings).followLocalOrigin &&
                 (this.particles[i] as TrailParticle).localPosition
             ) {
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 this.particles[i].position.copy((this.particles[i] as TrailParticle).localPosition!);
+
                 if (this.particles[i].parentMatrix) {
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     this.particles[i].position.applyMatrix4(this.particles[i].parentMatrix!);
                 } else {
                     this.particles[i].position.applyMatrix4(this.emitter.matrixWorld as unknown as Matrix4);
@@ -1034,9 +1051,10 @@ export class ParticleSystem implements IParticleSystem {
             } else {
                 this.particles[i].position.addScaledVector(
                     this.particles[i].velocity,
-                    delta * this.particles[i].speedModifier,
+                    delta * this.particles[i].speedModifier
                 );
             }
+
             this.particles[i].age += delta;
         }
 
@@ -1047,26 +1065,27 @@ export class ParticleSystem implements IParticleSystem {
             }
         }
 
-        // particle die
+        // Particle died
         for (let i = 0; i < this.particleNum; i++) {
             const particle = this.particles[i];
+
             if (particle.died && (!(particle instanceof TrailParticle) || particle.previous.length === 0)) {
                 this.particles[i] = this.particles[this.particleNum - 1];
                 this.particles[this.particleNum - 1] = particle;
                 this.particleNum--;
                 i--;
-                this.fire({type: "particleDied", particleSystem: this, particle: particle});
+                this.fire({type: 'particleDied', particleSystem: this, particle: particle});
             }
         }
     }
 
     /**
-     * Emit particles
-     * @param delta the duration of the frame
-     * @param emissionState the state of the emission
-     * @param emitterMatrix the matrix of the emitter
+     * Emit particles for a frame.
+     * @param delta - Frame duration in seconds.
+     * @param emissionState - The emission state to advance.
+     * @param emitterMatrix - The emitter world matrix.
      */
-    public emit(delta: number, emissionState: EmissionState, emitterMatrix: Matrix4) {
+    emit(delta: number, emissionState: EmissionState, emitterMatrix: Matrix4) {
         if (emissionState.time > this.duration) {
             if (this.looping) {
                 emissionState.time -= this.duration;
@@ -1081,18 +1100,18 @@ export class ParticleSystem implements IParticleSystem {
             }
         }
 
-        this.normalMatrix.getNormalMatrix(emitterMatrix);
+        this._normalMatrix.getNormalMatrix(emitterMatrix);
 
-        // spawn
+        // Spawn
         const totalSpawn = Math.ceil(emissionState.waitEmiting);
         this.spawn(totalSpawn, emissionState, emitterMatrix);
         emissionState.waitEmiting -= totalSpawn;
 
-        // spawn burst
+        // Spawn burst
         while (
             emissionState.burstIndex < this.emissionBursts.length &&
             this.emissionBursts[emissionState.burstIndex].time <= emissionState.time
-            ) {
+        ) {
             if (Math.random() < this.emissionBursts[emissionState.burstIndex].probability) {
                 const count = this.emissionBursts[emissionState.burstIndex].count.genValue(this.memory, this.time);
                 emissionState.isBursting = true;
@@ -1100,6 +1119,7 @@ export class ParticleSystem implements IParticleSystem {
                 this.spawn(count, emissionState, emitterMatrix);
                 emissionState.isBursting = false;
             }
+
             emissionState.burstIndex++;
         }
 
@@ -1108,12 +1128,14 @@ export class ParticleSystem implements IParticleSystem {
                 delta * this.emissionOverTime.genValue(this.memory, emissionState.time / this.duration);
 
             if (emissionState.previousWorldPos != undefined) {
-                this.temp.set(emitterMatrix.elements[12], emitterMatrix.elements[13], emitterMatrix.elements[14]);
-                emissionState.travelDistance += emissionState.previousWorldPos.distanceTo(this.temp);
+                this._vA.set(emitterMatrix.elements[12], emitterMatrix.elements[13], emitterMatrix.elements[14]);
+                emissionState.travelDistance += emissionState.previousWorldPos.distanceTo(this._vA);
+
                 const emitPerMeter = this.emissionOverDistance.genValue(
                     this.memory,
-                    emissionState.time / this.duration,
+                    emissionState.time / this.duration
                 );
+
                 if (emissionState.travelDistance * emitPerMeter > 0) {
                     const count = Math.floor(emissionState.travelDistance * emitPerMeter);
                     emissionState.travelDistance -= count / emitPerMeter;
@@ -1121,24 +1143,27 @@ export class ParticleSystem implements IParticleSystem {
                 }
             }
         }
+
         if (emissionState.previousWorldPos === undefined) emissionState.previousWorldPos = new Vector3();
+
         emissionState.previousWorldPos.set(
             emitterMatrix.elements[12],
             emitterMatrix.elements[13],
-            emitterMatrix.elements[14],
+            emitterMatrix.elements[14]
         );
+
         emissionState.time += delta;
     }
 
     /**
-     * output the particle system to JSON
-     * @param meta serialization meta data
-     * @param options serialization options
+     * Serialize the particle system to JSON.
+     * @param meta - Serialization metadata.
+     * @param options - Serialization options.
      */
     toJSON(meta: MetaData, options: SerializationOptions = {}): ParticleSystemJSONParameters {
         const isRootObject = meta === undefined || typeof meta === 'string';
+
         if (isRootObject) {
-            // initialize meta obj
             meta = {
                 geometries: {},
                 materials: {},
@@ -1162,8 +1187,11 @@ export class ParticleSystem implements IParticleSystem {
                 };
             }
         }
+
         // TODO: support URL
+
         let rendererSettingsJSON;
+
         if (this.renderMode === RenderMode.Trail) {
             rendererSettingsJSON = {
                 startLength: (this.rendererEmitterSettings as TrailSettings).startLength.toJSON(),
@@ -1171,7 +1199,6 @@ export class ParticleSystem implements IParticleSystem {
             };
         } else if (this.renderMode === RenderMode.Mesh) {
             rendererSettingsJSON = {};
-            /*;*/
         } else if (this.renderMode === RenderMode.StretchedBillBoard) {
             rendererSettingsJSON = {
                 speedFactor: (this.rendererEmitterSettings as StretchedBillBoardSettings).speedFactor,
@@ -1180,17 +1207,19 @@ export class ParticleSystem implements IParticleSystem {
         } else {
             rendererSettingsJSON = {};
         }
+
         const geometry = this.rendererSettings.instancingGeometry;
+
         if (meta.geometries && !meta.geometries[geometry.uuid]) {
             meta.geometries[geometry.uuid] = geometry.toJSON();
         }
+
         return {
             version: '3.0',
             autoDestroy: this.autoDestroy,
             looping: this.looping,
             prewarm: this.prewarm,
             duration: this.duration,
-
             shape: this.emitterShape.toJSON(),
             startLife: this.startLife.toJSON(),
             startSpeed: this.startSpeed.toJSON(),
@@ -1207,13 +1236,10 @@ export class ParticleSystem implements IParticleSystem {
                 cycle: burst.cycle,
             })),
             onlyUsedByOther: this.onlyUsedByOther,
-
-            instancingGeometry: this.rendererSettings.instancingGeometry.uuid, //Array.from(this.emitter.interleavedBuffer.array as Float32Array),
+            instancingGeometry: this.rendererSettings.instancingGeometry.uuid,
             renderOrder: this.renderOrder,
             renderMode: this.renderMode,
             rendererEmitterSettings: rendererSettingsJSON,
-            //speedFactor: this.renderMode === RenderMode.StretchedBillBoard ? this.speedFactor : 0,
-            //texture: this.texture.uuid,
             material: this.rendererSettings.material.uuid,
             layers: this.layers.mask,
             startTileIndex: this.startTileIndex.toJSON(),
@@ -1223,26 +1249,25 @@ export class ParticleSystem implements IParticleSystem {
             softParticles: this.rendererSettings.softParticles,
             softFarFade: this.rendererSettings.softFarFade,
             softNearFade: this.rendererSettings.softNearFade,
-
             behaviors: this.behaviors.map((behavior) => behavior.toJSON()),
-
             worldSpace: this.worldSpace,
         };
     }
 
     /**
-     * Create a ParticleSystem from JSON
-     * @param json the JSON data
-     * @param meta serialization meta data
-     * @param dependencies the dependencies of the particle system
+     * Create a ParticleSystem from JSON.
+     * @param json - The JSON data.
+     * @param meta - Serialization metadata.
+     * @param dependencies - Behavior dependency map populated while deserializing sub-emitters.
      */
     static fromJSON(
         json: ParticleSystemJSONParameters,
         meta: ThreeMetaData,
-        dependencies: {[uuid: string]: Behavior},
+        dependencies: {[uuid: string]: Behavior}
     ): ParticleSystem {
         const shape = EmitterFromJSON(json.shape, meta);
         let rendererEmitterSettings;
+
         if (json.renderMode === RenderMode.Trail) {
             const trailSettings = json.rendererEmitterSettings as TrailSettings;
             rendererEmitterSettings = {
@@ -1264,26 +1289,30 @@ export class ParticleSystem implements IParticleSystem {
         }
 
         const layers = new Layers();
+
         if (json.layers) {
             layers.mask = json.layers;
         }
+
         const ps = new ParticleSystem({
             autoDestroy: json.autoDestroy,
             looping: json.looping,
             prewarm: json.prewarm,
             duration: json.duration,
-
             shape: shape,
             startLife: ValueGeneratorFromJSON(json.startLife),
             startSpeed: ValueGeneratorFromJSON(json.startSpeed),
-            startRotation: GeneratorFromJSON(json.startRotation) as (RotationGenerator | ValueGenerator | FunctionValueGenerator),
-            startSize: GeneratorFromJSON(json.startSize) as (Vector3Generator | ValueGenerator | FunctionValueGenerator),
+            startRotation: GeneratorFromJSON(json.startRotation) as
+                | RotationGenerator
+                | ValueGenerator
+                | FunctionValueGenerator,
+            startSize: GeneratorFromJSON(json.startSize) as Vector3Generator | ValueGenerator | FunctionValueGenerator,
             startColor: ColorGeneratorFromJSON(json.startColor) as ColorGenerator,
             emissionOverTime: ValueGeneratorFromJSON(json.emissionOverTime),
             emissionOverDistance: ValueGeneratorFromJSON(json.emissionOverDistance),
             emissionBursts: json.emissionBursts?.map((burst) => ({
                 time: burst.time,
-                // backward compatibility
+                // Backward compatibility
                 count:
                     typeof burst.count === 'number'
                         ? new ConstantValue(burst.count)
@@ -1293,7 +1322,6 @@ export class ParticleSystem implements IParticleSystem {
                 cycle: burst.cycle ?? 1,
             })),
             onlyUsedByOther: json.onlyUsedByOther,
-
             instancingGeometry: meta.geometries[json.instancingGeometry],
             renderMode: json.renderMode,
             rendererEmitterSettings: rendererEmitterSettings,
@@ -1302,13 +1330,13 @@ export class ParticleSystem implements IParticleSystem {
             material: json.material
                 ? meta.materials[json.material]
                 : json.texture
-                    ? new MeshBasicMaterial({
+                  ? new MeshBasicMaterial({
                         map: meta.textures[json.texture],
                         transparent: json.transparent ?? true,
                         blending: json.blending,
                         side: DoubleSide,
                     })
-                    : new MeshBasicMaterial({
+                  : new MeshBasicMaterial({
                         color: 0xffffff,
                         transparent: true,
                         blending: AdditiveBlending,
@@ -1324,50 +1352,66 @@ export class ParticleSystem implements IParticleSystem {
             softParticles: json.softParticles,
             softFarFade: json.softFarFade,
             softNearFade: json.softNearFade,
-
             behaviors: [],
-
             worldSpace: json.worldSpace,
         });
-        ps.behaviors = json.behaviors.map((behaviorJson) => {
-            const behavior = BehaviorFromJSON(behaviorJson, ps);
-            if (behavior && behavior.type === 'EmitSubParticleSystem') {
-                dependencies[behaviorJson.subParticleSystem] = behavior;
-            }
-            return behavior;
-        }).filter(behavior => behavior !== null) as Behavior[];
+
+        ps.behaviors = json.behaviors
+            .map((behaviorJson) => {
+                const behavior = BehaviorFromJSON(behaviorJson, ps);
+                if (behavior && behavior.type === 'EmitSubParticleSystem') {
+                    dependencies[behaviorJson.subParticleSystem] = behavior;
+                }
+
+                return behavior;
+            })
+            .filter((behavior): behavior is Behavior => behavior !== null);
+
         return ps;
     }
 
     /**
-     * Add a behavior to the particle system
-     * @param behavior
+     * Add a behavior to the particle system.
+     * @param behavior - Behavior to add.
      */
     addBehavior(behavior: Behavior) {
         this.behaviors.push(behavior);
     }
 
     /**
-     * Remove a behavior from the particle system
+     * Get the renderer settings used to batch this particle system.
      */
     getRendererSettings() {
         return this.rendererSettings;
     }
 
+    /**
+     * Add an event listener.
+     * @param event - Event type to listen for.
+     * @param callback - Callback invoked when the event fires.
+     */
     addEventListener(event: ParticleSystemEventType, callback: (event: ParticleSystemEvent) => void): void {
-        if (!this.listeners[event])
-            this.listeners[event] = [];
+        if (!this.listeners[event]) this.listeners[event] = [];
         this.listeners[event].push(callback);
     }
 
+    /**
+     * Remove all listeners for an event type.
+     * @param event - Event type to clear.
+     */
     removeAllEventListeners(event: ParticleSystemEventType): void {
-        if (this.listeners[event])
-            this.listeners[event] = [];
+        if (this.listeners[event]) this.listeners[event] = [];
     }
 
+    /**
+     * Remove a specific event listener.
+     * @param event - Event type to remove from.
+     * @param callback - Callback to remove.
+     */
     removeEventListener(event: ParticleSystemEventType, callback: (event: ParticleSystemEvent) => void): void {
         if (this.listeners[event]) {
             const index = this.listeners[event].indexOf(callback);
+
             if (index !== -1) {
                 this.listeners[event].splice(index, 1);
             }
@@ -1375,28 +1419,28 @@ export class ParticleSystem implements IParticleSystem {
     }
 
     private fire(event: ParticleSystemEvent) {
-        if (this.listeners[event.type]) {
-            this.listeners[event.type].forEach(callback => callback(event));
-        }
+        this.listeners[event.type]?.forEach((callback) => callback(event));
     }
 
     /**
-     * Clone the particle system
+     * Clone the particle system.
      */
     clone() {
-        const newEmissionBursts: Array<BurstParameters> = [];
+        const newEmissionBursts: BurstParameters[] = [];
+        const newBehaviors: Behavior[] = [];
+
         for (const emissionBurst of this.emissionBursts) {
             const newEmissionBurst = {};
             Object.assign(newEmissionBurst, emissionBurst);
             newEmissionBursts.push(newEmissionBurst as BurstParameters);
         }
 
-        const newBehaviors: Array<Behavior> = [];
         for (const behavior of this.behaviors) {
             newBehaviors.push(behavior.clone());
         }
 
         let rendererEmitterSettings;
+
         if (this.renderMode === RenderMode.Trail) {
             rendererEmitterSettings = {
                 startLength: (this.rendererEmitterSettings as TrailSettings).startLength.clone(),
@@ -1418,7 +1462,6 @@ export class ParticleSystem implements IParticleSystem {
             autoDestroy: this.autoDestroy,
             looping: this.looping,
             duration: this.duration,
-
             shape: this.emitterShape.clone(),
             startLife: this.startLife.clone(),
             startSpeed: this.startSpeed.clone(),
@@ -1429,8 +1472,7 @@ export class ParticleSystem implements IParticleSystem {
             emissionOverDistance: this.emissionOverDistance.clone(),
             emissionBursts: newEmissionBursts,
             onlyUsedByOther: this.onlyUsedByOther,
-
-            instancingGeometry: this.rendererSettings.instancingGeometry, //.interleavedBuffer.array,
+            instancingGeometry: this.rendererSettings.instancingGeometry,
             renderMode: this.renderMode,
             renderOrder: this.renderOrder,
             rendererEmitterSettings: rendererEmitterSettings,
@@ -1442,9 +1484,7 @@ export class ParticleSystem implements IParticleSystem {
             softParticles: this.softParticles,
             softFarFade: this.softFarFade,
             softNearFade: this.softNearFade,
-
             behaviors: newBehaviors,
-
             worldSpace: this.worldSpace,
             layers: layers,
         });

--- a/packages/three.quarks/src/ParticleSystem.ts
+++ b/packages/three.quarks/src/ParticleSystem.ts
@@ -973,7 +973,8 @@ export class ParticleSystem implements IParticleSystem {
     ): void {
         if (renderMode === RenderMode.Trail && (this.rendererEmitterSettings as TrailSettings).followLocalOrigin) {
             const trail = particle as TrailParticle;
-            trail.localPosition = new Vector3().copy(trail.position);
+            trail.localPosition ??= new Vector3();
+            trail.localPosition.copy(trail.position);
         }
 
         if (this.worldSpace) {

--- a/packages/three.quarks/src/ParticleSystem.ts
+++ b/packages/three.quarks/src/ParticleSystem.ts
@@ -1,5 +1,4 @@
 import {
-    AxisAngleGenerator,
     Behavior,
     BehaviorFromJSON,
     ColorGenerator,
@@ -47,12 +46,12 @@ import {
     MeshBasicMaterial,
     Object3D,
     Object3DEventMap,
-    PlaneGeometry,
     Texture,
 } from 'three';
 
 import {BatchedRenderer, VFXBatchSettings} from './BatchedRenderer';
 import {MetaData, ParticleEmitter} from './ParticleEmitter';
+import {RendererDefaults} from './util/RendererDefaults';
 import {ThreeMetaData} from './util/ThreeUtil';
 import {RenderMode} from './VFXBatch';
 
@@ -259,7 +258,6 @@ export interface ParticleSystemJSONParameters {
 }
 
 const PREWARM_FPS = 60;
-const DEFAULT_GEOMETRY = new PlaneGeometry(1, 1, 1, 1);
 const UP = new Vector3(0, 0, 1);
 
 /**
@@ -624,8 +622,12 @@ export class ParticleSystem implements IParticleSystem {
         if (previousRenderMode === renderMode) return;
 
         const shouldRestart = this.needsRestartForRenderModeChange(previousRenderMode, renderMode);
+        const defaults = RendererDefaults.createRenderModeTransitionDefaults(previousRenderMode, renderMode);
 
-        this.applyRenderModeDefaults(previousRenderMode, renderMode);
+        if (defaults.rendererEmitterSettings) this.rendererEmitterSettings = defaults.rendererEmitterSettings;
+        if (defaults.startRotation) this.startRotation = defaults.startRotation;
+        if (defaults.instancingGeometry) this.rendererSettings.instancingGeometry = defaults.instancingGeometry;
+
         this.rendererSettings.renderMode = renderMode;
 
         if (shouldRestart) {
@@ -731,9 +733,10 @@ export class ParticleSystem implements IParticleSystem {
         const rendererEmitterSettings = parameters.rendererEmitterSettings ?? {};
 
         if (parameters.renderMode === RenderMode.StretchedBillBoard) {
-            const sbbSettings = rendererEmitterSettings as StretchedBillBoardSettings;
-            sbbSettings.speedFactor = parameters.speedFactor ?? sbbSettings.speedFactor ?? 0;
-            sbbSettings.lengthFactor = sbbSettings.lengthFactor ?? 0;
+            const stretchedSettings = rendererEmitterSettings as StretchedBillBoardSettings;
+
+            stretchedSettings.speedFactor = parameters.speedFactor ?? stretchedSettings.speedFactor ?? 0;
+            stretchedSettings.lengthFactor = stretchedSettings.lengthFactor ?? 0;
         }
 
         return rendererEmitterSettings;
@@ -741,7 +744,7 @@ export class ParticleSystem implements IParticleSystem {
 
     private createRendererSettings(parameters: ParticleSystemParameters): VFXBatchSettings {
         return {
-            instancingGeometry: parameters.instancingGeometry ?? DEFAULT_GEOMETRY,
+            instancingGeometry: parameters.instancingGeometry ?? RendererDefaults.getDefaultGeometry(),
             renderMode: parameters.renderMode ?? RenderMode.BillBoard,
             renderOrder: parameters.renderOrder ?? 0,
             material: parameters.material,
@@ -753,6 +756,67 @@ export class ParticleSystem implements IParticleSystem {
             softFarFade: parameters.softFarFade ?? 0,
             layers: parameters.layers ?? new Layers(),
         };
+    }
+
+    private static createRendererEmitterSettingsFromJSON(json: ParticleSystemJSONParameters): RendererEmitterSettings {
+        switch (json.renderMode) {
+            case RenderMode.Trail: {
+                const trailSettings = json.rendererEmitterSettings as TrailSettings;
+
+                return {
+                    startLength:
+                        trailSettings.startLength != undefined
+                            ? ValueGeneratorFromJSON(trailSettings.startLength)
+                            : new ConstantValue(30),
+                    followLocalOrigin: trailSettings.followLocalOrigin,
+                };
+            }
+            case RenderMode.StretchedBillBoard: {
+                const rendererEmitterSettings = json.rendererEmitterSettings;
+
+                if (json.speedFactor != undefined) {
+                    (rendererEmitterSettings as StretchedBillBoardSettings).speedFactor = json.speedFactor;
+                }
+
+                return rendererEmitterSettings;
+            }
+            default:
+                return {};
+        }
+    }
+
+    private rendererEmitterSettingsToJSON(): any {
+        switch (this.renderMode) {
+            case RenderMode.Trail:
+                return {
+                    startLength: (this.rendererEmitterSettings as TrailSettings).startLength.toJSON(),
+                    followLocalOrigin: (this.rendererEmitterSettings as TrailSettings).followLocalOrigin,
+                };
+            case RenderMode.StretchedBillBoard:
+                return {
+                    speedFactor: (this.rendererEmitterSettings as StretchedBillBoardSettings).speedFactor,
+                    lengthFactor: (this.rendererEmitterSettings as StretchedBillBoardSettings).lengthFactor,
+                };
+            default:
+                return {};
+        }
+    }
+
+    private cloneRendererEmitterSettings(): RendererEmitterSettings {
+        switch (this.renderMode) {
+            case RenderMode.Trail:
+                return {
+                    startLength: (this.rendererEmitterSettings as TrailSettings).startLength.clone(),
+                    followLocalOrigin: (this.rendererEmitterSettings as TrailSettings).followLocalOrigin,
+                };
+            case RenderMode.StretchedBillBoard:
+                return {
+                    lengthFactor: (this.rendererEmitterSettings as StretchedBillBoardSettings).lengthFactor,
+                    speedFactor: (this.rendererEmitterSettings as StretchedBillBoardSettings).speedFactor,
+                };
+            default:
+                return {};
+        }
     }
 
     private createEmissionState(): EmissionState {
@@ -780,35 +844,6 @@ export class ParticleSystem implements IParticleSystem {
         // Keep render-mode restart policy named even while it is simple so the setter
         // does not become the dumping ground for future transition edge cases.
         return previousRenderMode === RenderMode.Trail || renderMode === RenderMode.Trail;
-    }
-
-    private applyRenderModeDefaults(previousRenderMode: RenderMode, renderMode: RenderMode): void {
-        if (previousRenderMode === RenderMode.Mesh) {
-            this.startRotation = new ConstantValue(0);
-        }
-
-        switch (renderMode) {
-            case RenderMode.Trail:
-                this.rendererEmitterSettings = {
-                    startLength: new ConstantValue(30),
-                    followLocalOrigin: false,
-                };
-                break;
-            case RenderMode.Mesh:
-                this.rendererEmitterSettings = {geometry: DEFAULT_GEOMETRY};
-                this.startRotation = new AxisAngleGenerator(new Vector3(0, 1, 0), new ConstantValue(0));
-                break;
-            case RenderMode.StretchedBillBoard:
-                this.rendererEmitterSettings = {speedFactor: 0, lengthFactor: 2};
-                this.rendererSettings.instancingGeometry = DEFAULT_GEOMETRY;
-                break;
-            case RenderMode.BillBoard:
-            case RenderMode.VerticalBillBoard:
-            case RenderMode.HorizontalBillBoard:
-                this.rendererEmitterSettings = {};
-                this.rendererSettings.instancingGeometry = DEFAULT_GEOMETRY;
-                break;
-        }
     }
 
     private spawn(count: number, emissionState: EmissionState, matrix: Matrix4) {
@@ -860,6 +895,7 @@ export class ParticleSystem implements IParticleSystem {
                     particle.memory,
                     emissionState.time / this.duration
                 );
+
                 particle.startSize.set(size, size, size);
             }
 
@@ -963,8 +999,7 @@ export class ParticleSystem implements IParticleSystem {
      * Remove the particle system's emitter from the scene and release emitter resources.
      */
     dispose() {
-        if (this._renderer) this._renderer.deleteSystem(this);
-
+        this._renderer?.deleteSystem(this);
         this.emitter.removeFromParent();
         this.emitter.dispose();
 
@@ -1044,6 +1079,7 @@ export class ParticleSystem implements IParticleSystem {
 
         for (let j = 0; j < this.behaviors.length; j++) {
             this.behaviors[j].frameUpdate(delta);
+
             for (let i = 0; i < this.particleNum; i++) {
                 if (!this.particles[i].died) {
                     this.behaviors[j].update(this.particles[i], delta);
@@ -1089,6 +1125,7 @@ export class ParticleSystem implements IParticleSystem {
                 this.particles[this.particleNum - 1] = particle;
                 this.particleNum--;
                 i--;
+
                 this.fire({type: 'particleDied', particleSystem: this, particle: particle});
             }
         }
@@ -1105,9 +1142,7 @@ export class ParticleSystem implements IParticleSystem {
             if (this.looping) {
                 emissionState.time -= this.duration;
                 emissionState.burstIndex = 0;
-                this.behaviors.forEach((behavior) => {
-                    behavior.reset();
-                });
+                this.behaviors.forEach((behavior) => behavior.reset());
             } else {
                 if (!this.emitEnded && !this.onlyUsedByOther) {
                     this.endEmit();
@@ -1205,24 +1240,6 @@ export class ParticleSystem implements IParticleSystem {
 
         // TODO: support URL
 
-        let rendererSettingsJSON;
-
-        if (this.renderMode === RenderMode.Trail) {
-            rendererSettingsJSON = {
-                startLength: (this.rendererEmitterSettings as TrailSettings).startLength.toJSON(),
-                followLocalOrigin: (this.rendererEmitterSettings as TrailSettings).followLocalOrigin,
-            };
-        } else if (this.renderMode === RenderMode.Mesh) {
-            rendererSettingsJSON = {};
-        } else if (this.renderMode === RenderMode.StretchedBillBoard) {
-            rendererSettingsJSON = {
-                speedFactor: (this.rendererEmitterSettings as StretchedBillBoardSettings).speedFactor,
-                lengthFactor: (this.rendererEmitterSettings as StretchedBillBoardSettings).lengthFactor,
-            };
-        } else {
-            rendererSettingsJSON = {};
-        }
-
         const geometry = this.rendererSettings.instancingGeometry;
 
         if (meta.geometries && !meta.geometries[geometry.uuid]) {
@@ -1254,7 +1271,7 @@ export class ParticleSystem implements IParticleSystem {
             instancingGeometry: this.rendererSettings.instancingGeometry.uuid,
             renderOrder: this.renderOrder,
             renderMode: this.renderMode,
-            rendererEmitterSettings: rendererSettingsJSON,
+            rendererEmitterSettings: this.rendererEmitterSettingsToJSON(),
             material: this.rendererSettings.material.uuid,
             layers: this.layers.mask,
             startTileIndex: this.startTileIndex.toJSON(),
@@ -1281,28 +1298,6 @@ export class ParticleSystem implements IParticleSystem {
         dependencies: {[uuid: string]: Behavior}
     ): ParticleSystem {
         const shape = EmitterFromJSON(json.shape, meta);
-        let rendererEmitterSettings;
-
-        if (json.renderMode === RenderMode.Trail) {
-            const trailSettings = json.rendererEmitterSettings as TrailSettings;
-            rendererEmitterSettings = {
-                startLength:
-                    trailSettings.startLength != undefined
-                        ? ValueGeneratorFromJSON(trailSettings.startLength)
-                        : new ConstantValue(30),
-                followLocalOrigin: trailSettings.followLocalOrigin,
-            };
-        } else if (json.renderMode === RenderMode.Mesh) {
-            rendererEmitterSettings = {};
-        } else if (json.renderMode === RenderMode.StretchedBillBoard) {
-            rendererEmitterSettings = json.rendererEmitterSettings;
-            if (json.speedFactor != undefined) {
-                (rendererEmitterSettings as StretchedBillBoardSettings).speedFactor = json.speedFactor;
-            }
-        } else {
-            rendererEmitterSettings = {};
-        }
-
         const layers = new Layers();
 
         if (json.layers) {
@@ -1339,7 +1334,7 @@ export class ParticleSystem implements IParticleSystem {
             onlyUsedByOther: json.onlyUsedByOther,
             instancingGeometry: meta.geometries[json.instancingGeometry],
             renderMode: json.renderMode,
-            rendererEmitterSettings: rendererEmitterSettings,
+            rendererEmitterSettings: ParticleSystem.createRendererEmitterSettingsFromJSON(json),
             renderOrder: json.renderOrder,
             layers: layers,
             material: json.material
@@ -1452,22 +1447,6 @@ export class ParticleSystem implements IParticleSystem {
             newBehaviors.push(behavior.clone());
         }
 
-        let rendererEmitterSettings;
-
-        if (this.renderMode === RenderMode.Trail) {
-            rendererEmitterSettings = {
-                startLength: (this.rendererEmitterSettings as TrailSettings).startLength.clone(),
-                followLocalOrigin: (this.rendererEmitterSettings as TrailSettings).followLocalOrigin,
-            };
-        } else if (this.renderMode === RenderMode.StretchedBillBoard) {
-            rendererEmitterSettings = {
-                lengthFactor: (this.rendererEmitterSettings as StretchedBillBoardSettings).lengthFactor,
-                speedFactor: (this.rendererEmitterSettings as StretchedBillBoardSettings).speedFactor,
-            };
-        } else {
-            rendererEmitterSettings = {};
-        }
-
         const layers = new Layers();
         layers.mask = this.layers.mask;
 
@@ -1488,7 +1467,7 @@ export class ParticleSystem implements IParticleSystem {
             instancingGeometry: this.rendererSettings.instancingGeometry,
             renderMode: this.renderMode,
             renderOrder: this.renderOrder,
-            rendererEmitterSettings: rendererEmitterSettings,
+            rendererEmitterSettings: this.cloneRendererEmitterSettings(),
             material: this.rendererSettings.material,
             startTileIndex: this.startTileIndex,
             uTileCount: this.uTileCount,

--- a/packages/three.quarks/src/ParticleSystem.ts
+++ b/packages/three.quarks/src/ParticleSystem.ts
@@ -847,137 +847,147 @@ export class ParticleSystem implements IParticleSystem {
     }
 
     private spawn(count: number, emissionState: EmissionState, matrix: Matrix4) {
-        this._qA.setFromRotationMatrix(matrix as unknown as Matrix4);
+        const renderMode = this.rendererSettings.renderMode;
 
-        const translation = this._vA;
-        const quaternion = this._qA;
-        const scale = this._vB;
-
-        matrix.decompose(translation, quaternion, scale);
+        // vA: position, qA: rotation, vB: scale
+        matrix.decompose(this._vA, this._qA, this._vB);
 
         for (let i = 0; i < count; i++) {
             emissionState.burstParticleIndex = i;
-            this.particleNum++;
+            const particle = this.getNewParticle(renderMode);
+            const normalizedTime = emissionState.time / this.duration;
 
-            while (this.particles.length < this.particleNum) {
-                if (this.rendererSettings.renderMode === RenderMode.Trail) {
-                    this.particles.push(new TrailParticle());
-                } else {
-                    this.particles.push(new SpriteParticle());
-                }
-            }
-
-            const particle = this.particles[this.particleNum - 1];
-            particle.reset();
-            particle.speedModifier = 1;
-
-            this.startColor.startGen(particle.memory);
-            this.startColor.genColor(particle.memory, particle.startColor, this.emissionState.time);
-            particle.color.copy(particle.startColor);
-
-            this.startSpeed.startGen(particle.memory);
-            particle.startSpeed = this.startSpeed.genValue(particle.memory, emissionState.time / this.duration);
-
-            this.startLife.startGen(particle.memory);
-            particle.life = this.startLife.genValue(particle.memory, emissionState.time / this.duration);
-            particle.age = 0;
-
-            this.startSize.startGen(particle.memory);
-
-            if (this.startSize.type === 'vec3function') {
-                (this.startSize as Vector3Generator).genValue(
-                    particle.memory,
-                    particle.startSize,
-                    emissionState.time / this.duration
-                );
-            } else {
-                const size = (this.startSize as FunctionValueGenerator).genValue(
-                    particle.memory,
-                    emissionState.time / this.duration
-                );
-
-                particle.startSize.set(size, size, size);
-            }
-
-            this.startTileIndex.startGen(particle.memory);
-            particle.uvTile = this.startTileIndex.genValue(particle.memory);
-            particle.size.copy(particle.startSize);
-
-            if (
-                this.rendererSettings.renderMode === RenderMode.Mesh ||
-                this.rendererSettings.renderMode === RenderMode.BillBoard ||
-                this.rendererSettings.renderMode === RenderMode.VerticalBillBoard ||
-                this.rendererSettings.renderMode === RenderMode.HorizontalBillBoard ||
-                this.rendererSettings.renderMode === RenderMode.StretchedBillBoard
-            ) {
-                const sprite = particle as SpriteParticle;
-                this.startRotation.startGen(particle.memory);
-
-                if (this.rendererSettings.renderMode === RenderMode.Mesh) {
-                    if (!(sprite.rotation instanceof Quaternion)) {
-                        sprite.rotation = new Quaternion();
-                    }
-
-                    if (this.startRotation.type === 'rotation') {
-                        this.startRotation.genValue(
-                            particle.memory,
-                            sprite.rotation as Quaternion,
-                            1,
-                            emissionState.time / this.duration
-                        );
-                    } else {
-                        (sprite.rotation as Quaternion).setFromAxisAngle(
-                            UP,
-                            this.startRotation.genValue(sprite.memory, (emissionState.time / this.duration) as number)
-                        );
-                    }
-                } else {
-                    if (this.startRotation.type === 'rotation') {
-                        sprite.rotation = 0;
-                    } else {
-                        sprite.rotation = this.startRotation.genValue(
-                            sprite.memory,
-                            emissionState.time / this.duration
-                        );
-                    }
-                }
-            } else if (this.rendererSettings.renderMode === RenderMode.Trail) {
-                const trail = particle as TrailParticle;
-
-                (this.rendererEmitterSettings as TrailSettings).startLength.startGen(trail.memory);
-                trail.length = (this.rendererEmitterSettings as TrailSettings).startLength.genValue(
-                    trail.memory,
-                    emissionState.time / this.duration
-                );
-            }
+            this.initializeParticleBase(particle, normalizedTime);
+            this.initializeParticleRenderState(particle, normalizedTime, renderMode);
 
             this.emitterShape.initialize(particle, emissionState);
 
-            if (
-                this.rendererSettings.renderMode === RenderMode.Trail &&
-                (this.rendererEmitterSettings as TrailSettings).followLocalOrigin
-            ) {
-                const trail = particle as TrailParticle;
-                trail.localPosition = new Vector3().copy(trail.position);
-            }
-
-            if (this.worldSpace) {
-                particle.position.applyMatrix4(matrix);
-                particle.startSize.multiply(scale).abs();
-                particle.size.copy(particle.startSize);
-                particle.velocity.multiply(scale).applyMatrix3(this._normalMatrix);
-
-                if (particle.rotation && particle.rotation instanceof Quaternion) {
-                    particle.rotation.multiplyQuaternions(this._qA, particle.rotation);
-                }
-            } else {
-                if (this.onlyUsedByOther) {
-                    particle.parentMatrix = matrix;
-                }
-            }
+            this.applySpawnTransform(particle, matrix, this._qA, this._vB, renderMode);
 
             for (let j = 0; j < this.behaviors.length; j++) {
                 this.behaviors[j].initialize(particle, this);
+            }
+        }
+    }
+
+    private getNewParticle(renderMode: RenderMode): Particle {
+        this.particleNum++;
+
+        while (this.particles.length < this.particleNum) {
+            if (renderMode === RenderMode.Trail) {
+                this.particles.push(new TrailParticle());
+            } else {
+                this.particles.push(new SpriteParticle());
+            }
+        }
+
+        return this.particles[this.particleNum - 1];
+    }
+
+    private initializeParticleBase(particle: Particle, normalizedTime: number): void {
+        particle.reset();
+        particle.speedModifier = 1;
+
+        this.startColor.startGen(particle.memory);
+        this.startColor.genColor(particle.memory, particle.startColor, this.emissionState.time);
+        particle.color.copy(particle.startColor);
+
+        this.startSpeed.startGen(particle.memory);
+        particle.startSpeed = this.startSpeed.genValue(particle.memory, normalizedTime);
+
+        this.startLife.startGen(particle.memory);
+        particle.life = this.startLife.genValue(particle.memory, normalizedTime);
+        particle.age = 0;
+
+        this.startSize.startGen(particle.memory);
+
+        if (this.startSize.type === 'vec3function') {
+            this.startSize.genValue(particle.memory, particle.startSize, normalizedTime);
+        } else {
+            const size = this.startSize.genValue(particle.memory, normalizedTime);
+            particle.startSize.set(size, size, size);
+        }
+
+        this.startTileIndex.startGen(particle.memory);
+        particle.uvTile = this.startTileIndex.genValue(particle.memory);
+        particle.size.copy(particle.startSize);
+    }
+
+    private initializeParticleRenderState(particle: Particle, normalizedTime: number, renderMode: RenderMode): void {
+        switch (renderMode) {
+            case RenderMode.Mesh:
+            case RenderMode.BillBoard:
+            case RenderMode.VerticalBillBoard:
+            case RenderMode.HorizontalBillBoard:
+            case RenderMode.StretchedBillBoard:
+                this.initializeSpriteParticleRotation(particle as SpriteParticle, normalizedTime, renderMode);
+                break;
+
+            case RenderMode.Trail:
+                this.initializeTrailParticleLength(particle as TrailParticle, normalizedTime);
+                break;
+        }
+    }
+
+    private initializeSpriteParticleRotation(
+        sprite: SpriteParticle,
+        normalizedTime: number,
+        renderMode: RenderMode
+    ): void {
+        this.startRotation.startGen(sprite.memory);
+
+        if (renderMode !== RenderMode.Mesh) {
+            if (this.startRotation.type === 'rotation') {
+                sprite.rotation = 0;
+                return;
+            }
+
+            sprite.rotation = this.startRotation.genValue(sprite.memory, normalizedTime);
+            return;
+        }
+
+        if (!(sprite.rotation instanceof Quaternion)) {
+            sprite.rotation = new Quaternion();
+        }
+
+        if (this.startRotation.type === 'rotation') {
+            this.startRotation.genValue(sprite.memory, sprite.rotation, 1, normalizedTime);
+        } else {
+            sprite.rotation.setFromAxisAngle(UP, this.startRotation.genValue(sprite.memory, normalizedTime));
+        }
+    }
+
+    private initializeTrailParticleLength(trail: TrailParticle, normalizedTime: number): void {
+        const settings = this.rendererEmitterSettings as TrailSettings;
+
+        settings.startLength.startGen(trail.memory);
+        trail.length = settings.startLength.genValue(trail.memory, normalizedTime);
+    }
+
+    private applySpawnTransform(
+        particle: Particle,
+        matrix: Matrix4,
+        rotation: Quaternion,
+        scale: Vector3,
+        renderMode: RenderMode
+    ): void {
+        if (renderMode === RenderMode.Trail && (this.rendererEmitterSettings as TrailSettings).followLocalOrigin) {
+            const trail = particle as TrailParticle;
+            trail.localPosition = new Vector3().copy(trail.position);
+        }
+
+        if (this.worldSpace) {
+            particle.position.applyMatrix4(matrix);
+            particle.startSize.multiply(scale).abs();
+            particle.size.copy(particle.startSize);
+            particle.velocity.multiply(scale).applyMatrix3(this._normalMatrix);
+
+            if (particle.rotation instanceof Quaternion) {
+                particle.rotation.multiplyQuaternions(rotation, particle.rotation);
+            }
+        } else {
+            if (this.onlyUsedByOther) {
+                particle.parentMatrix = matrix;
             }
         }
     }

--- a/packages/three.quarks/src/ParticleSystem.ts
+++ b/packages/three.quarks/src/ParticleSystem.ts
@@ -849,6 +849,7 @@ export class ParticleSystem implements IParticleSystem {
 
     private spawn(count: number, emissionState: EmissionState, matrix: Matrix4) {
         const renderMode = this.rendererSettings.renderMode;
+        const normalizedTime = emissionState.time / this.duration;
 
         // vA: position, qA: rotation, vB: scale
         matrix.decompose(this._vA, this._qA, this._vB);
@@ -856,7 +857,6 @@ export class ParticleSystem implements IParticleSystem {
         for (let i = 0; i < count; i++) {
             emissionState.burstParticleIndex = i;
             const particle = this.getNewParticle(renderMode);
-            const normalizedTime = emissionState.time / this.duration;
 
             this.initializeParticleBase(particle, normalizedTime);
             this.initializeParticleRenderState(particle, normalizedTime, renderMode);
@@ -1485,9 +1485,10 @@ export class ParticleSystem implements IParticleSystem {
         const newBehaviors: Behavior[] = [];
 
         for (const emissionBurst of this.emissionBursts) {
-            const newEmissionBurst = {};
-            Object.assign(newEmissionBurst, emissionBurst);
-            newEmissionBursts.push(newEmissionBurst as BurstParameters);
+            newEmissionBursts.push({
+                ...emissionBurst,
+                count: emissionBurst.count.clone(),
+            });
         }
 
         for (const behavior of this.behaviors) {
@@ -1500,6 +1501,7 @@ export class ParticleSystem implements IParticleSystem {
         return new ParticleSystem({
             autoDestroy: this.autoDestroy,
             looping: this.looping,
+            prewarm: this.prewarm,
             duration: this.duration,
             shape: this.emitterShape.clone(),
             startLife: this.startLife.clone(),
@@ -1516,7 +1518,7 @@ export class ParticleSystem implements IParticleSystem {
             renderOrder: this.renderOrder,
             rendererEmitterSettings: this.cloneRendererEmitterSettings(),
             material: this.rendererSettings.material,
-            startTileIndex: this.startTileIndex,
+            startTileIndex: this.startTileIndex.clone(),
             uTileCount: this.uTileCount,
             vTileCount: this.vTileCount,
             blendTiles: this.blendTiles,

--- a/packages/three.quarks/src/ParticleSystem.ts
+++ b/packages/three.quarks/src/ParticleSystem.ts
@@ -1156,23 +1156,13 @@ export class ParticleSystem implements IParticleSystem {
      * @param emitterMatrix - The emitter world matrix.
      */
     emit(delta: number, emissionState: EmissionState, emitterMatrix: Matrix4) {
-        if (emissionState.time > this.duration) {
-            if (this.looping) {
-                emissionState.time -= this.duration;
-                emissionState.burstIndex = 0;
-                this.behaviors.forEach((behavior) => behavior.reset());
-            } else {
-                if (!this.emitEnded && !this.onlyUsedByOther) {
-                    this.endEmit();
-                }
-            }
-        }
-
+        this.updateEmissionDuration(emissionState);
         this._normalMatrix.getNormalMatrix(emitterMatrix);
 
         // Spawn
         const totalSpawn = Math.ceil(emissionState.waitEmiting);
         this.spawn(totalSpawn, emissionState, emitterMatrix);
+
         emissionState.waitEmiting -= totalSpawn;
 
         // Spawn burst
@@ -1180,10 +1170,13 @@ export class ParticleSystem implements IParticleSystem {
             emissionState.burstIndex < this.emissionBursts.length &&
             this.emissionBursts[emissionState.burstIndex].time <= emissionState.time
         ) {
-            if (Math.random() < this.emissionBursts[emissionState.burstIndex].probability) {
-                const count = this.emissionBursts[emissionState.burstIndex].count.genValue(this.memory, this.time);
+            const burst = this.emissionBursts[emissionState.burstIndex];
+
+            if (Math.random() < burst.probability) {
+                const count = burst.count.genValue(this.memory, this.time);
                 emissionState.isBursting = true;
                 emissionState.burstParticleCount = count;
+
                 this.spawn(count, emissionState, emitterMatrix);
                 emissionState.isBursting = false;
             }
@@ -1191,36 +1184,52 @@ export class ParticleSystem implements IParticleSystem {
             emissionState.burstIndex++;
         }
 
+        const emitterPosition = this._vA.set(
+            emitterMatrix.elements[12],
+            emitterMatrix.elements[13],
+            emitterMatrix.elements[14]
+        );
+
         if (!this.emitEnded) {
-            emissionState.waitEmiting +=
-                delta * this.emissionOverTime.genValue(this.memory, emissionState.time / this.duration);
+            const normalizedTime = emissionState.time / this.duration;
+            emissionState.waitEmiting += delta * this.emissionOverTime.genValue(this.memory, normalizedTime);
 
-            if (emissionState.previousWorldPos != undefined) {
-                this._vA.set(emitterMatrix.elements[12], emitterMatrix.elements[13], emitterMatrix.elements[14]);
-                emissionState.travelDistance += emissionState.previousWorldPos.distanceTo(this._vA);
+            if (emissionState.previousWorldPos) {
+                emissionState.travelDistance += emissionState.previousWorldPos.distanceTo(emitterPosition);
 
-                const emitPerMeter = this.emissionOverDistance.genValue(
-                    this.memory,
-                    emissionState.time / this.duration
-                );
+                const emitPerMeter = this.emissionOverDistance.genValue(this.memory, normalizedTime);
+                const spawnDistance = emissionState.travelDistance * emitPerMeter;
 
-                if (emissionState.travelDistance * emitPerMeter > 0) {
-                    const count = Math.floor(emissionState.travelDistance * emitPerMeter);
+                if (spawnDistance > 0) {
+                    const count = Math.floor(spawnDistance);
                     emissionState.travelDistance -= count / emitPerMeter;
                     emissionState.waitEmiting += count;
                 }
             }
         }
 
-        if (emissionState.previousWorldPos === undefined) emissionState.previousWorldPos = new Vector3();
-
-        emissionState.previousWorldPos.set(
-            emitterMatrix.elements[12],
-            emitterMatrix.elements[13],
-            emitterMatrix.elements[14]
-        );
-
+        emissionState.previousWorldPos ??= new Vector3();
+        emissionState.previousWorldPos.copy(emitterPosition);
         emissionState.time += delta;
+    }
+
+    private updateEmissionDuration(emissionState: EmissionState): void {
+        if (emissionState.time <= this.duration) return;
+
+        if (this.looping) {
+            emissionState.time -= this.duration;
+            emissionState.burstIndex = 0;
+
+            for (const behavior of this.behaviors) {
+                behavior.reset();
+            }
+
+            return;
+        }
+
+        if (!this.emitEnded && !this.onlyUsedByOther) {
+            this.endEmit();
+        }
     }
 
     /**

--- a/packages/three.quarks/src/QuarksLoader.ts
+++ b/packages/three.quarks/src/QuarksLoader.ts
@@ -1,46 +1,46 @@
+import {Behavior, EmitSubParticleSystem} from 'quarks.core';
 import {
-    Texture,
-    Sprite,
-    Group,
-    Object3D,
-    LoadingManager,
-    ObjectLoader,
-    Material,
+    AmbientLight,
     AnimationClip,
-    Scene,
+    BatchedMesh,
+    Bone,
+    Box3,
+    BufferGeometry,
     Color,
+    DirectionalLight,
     Fog,
     FogExp2,
-    PerspectiveCamera,
-    OrthographicCamera,
-    AmbientLight,
-    DirectionalLight,
-    PointLight,
-    RectAreaLight,
+    Group,
     HemisphereLight,
+    InstancedBufferAttribute,
+    InstancedMesh,
+    LOD,
     LightProbe,
+    Line,
+    LineLoop,
+    LineSegments,
+    LoadingManager,
+    Material,
+    Mesh,
+    Object3D,
+    ObjectLoader,
+    OrthographicCamera,
+    PerspectiveCamera,
+    PointLight,
+    Points,
+    RectAreaLight,
+    Scene,
+    SkinnedMesh,
+    Sphere,
     SphericalHarmonics3,
     SpotLight,
-    SkinnedMesh,
-    Mesh,
-    InstancedMesh,
-    InstancedBufferAttribute,
-    LOD,
-    Line,
-    LineSegments,
-    LineLoop,
-    Points,
+    Sprite,
     SpriteMaterial,
-    Bone,
-    BufferGeometry,
-    BatchedMesh,
-    Sphere,
-    Box3,
+    Texture,
 } from 'three';
-import {ParticleSystem} from './ParticleSystem';
-import {Behavior, EmitSubParticleSystem} from 'quarks.core';
 import {ParticleEmitter} from './ParticleEmitter';
-import { QuarksPrefab } from './QuarksPrefab';
+import {ParticleSystem} from './ParticleSystem';
+import {QuarksPrefab} from './QuarksPrefab';
 
 /**
  * Loader for quarks particle system.
@@ -53,39 +53,43 @@ export class QuarksLoader extends ObjectLoader {
     /**
      * Links the references of the particle system.
      * It's used to link the references of sub particle systems.
-     * @param object the target object to link the references.
+     * @param object - The target object to link the references.
      */
     linkReference(object: Object3D) {
         const objectsMap: {[uuid: string]: Object3D} = {};
-        object.traverse(function (child) {
+        const particleEmitters: ParticleEmitter[] = [];
+
+        object.traverse((child) => {
             objectsMap[child.uuid] = child;
-        });
-        object.traverse(function (child) {
+
             if (child.type === 'ParticleEmitter') {
-                const system = (child as ParticleEmitter).system as ParticleSystem;
-                const shape = system.emitterShape;
-                /*if (shape instanceof MeshSurfaceEmitter) {
-                    shape.geometry = objectsMap[shape.geometry as any] as Mesh;
-                }*/
-                for (let i = 0; i < system.behaviors.length; i++) {
-                    if (system.behaviors[i] instanceof EmitSubParticleSystem) {
-                        (system.behaviors[i] as EmitSubParticleSystem).subParticleSystem = objectsMap[
-                            (system.behaviors[i] as EmitSubParticleSystem).subParticleSystem as any
-                        ] as ParticleEmitter;
-                    }
-                }
+                particleEmitters.push(child as ParticleEmitter);
             }
         });
+
+        for (const emitter of particleEmitters) {
+            const system = emitter.system as ParticleSystem;
+
+            for (const behavior of system.behaviors) {
+                if (!(behavior instanceof EmitSubParticleSystem)) continue;
+
+                const subParticleSystemId = behavior.subParticleSystem as unknown;
+                if (typeof subParticleSystemId !== 'string') continue;
+
+                behavior.subParticleSystem = objectsMap[subParticleSystemId] as ParticleEmitter;
+            }
+        }
     }
 
     /**
      * Parses the json data to create a quarks particle system.
-     * @param json the json data to parse.
-     * @param onLoad the callback function to be called after the object is loaded.
+     * @param json - The json data to parse.
+     * @param onLoad - The callback function to be called after the object is loaded.
      */
     parse<T extends Object3D>(json: any, onLoad?: (object: Object3D) => void): T {
         const object = super.parse(json, onLoad);
         this.linkReference(object);
+
         return object as T;
     }
 
@@ -97,69 +101,35 @@ export class QuarksLoader extends ObjectLoader {
         textures: {[uuid: string]: Texture},
         animations: {[uuid: string]: AnimationClip}
     ): Object3D {
-        let object;
-        function getGeometry(name: string) {
-            if (geometries[name] === undefined) {
-                console.warn('THREE.ObjectLoader: Undefined geometry', name);
-            }
-            return geometries[name];
-        }
-
-        function getMaterial(name: string | string[] | undefined) {
-            if (name === undefined) return undefined;
-            if (Array.isArray(name)) {
-                const array = [];
-                for (let i = 0, l = name.length; i < l; i++) {
-                    const uuid = name[i];
-                    if (materials[uuid] === undefined) {
-                        console.warn('THREE.ObjectLoader: Undefined material', uuid);
-                    }
-                    array.push(materials[uuid]);
-                }
-                return array;
-            }
-
-            if (materials[name] === undefined) {
-                console.warn('THREE.ObjectLoader: Undefined material', name);
-            }
-
-            return materials[name];
-        }
-
-        function getTexture(uuid: string) {
-            if (textures[uuid] === undefined) {
-                console.warn('THREE.ObjectLoader: Undefined texture', uuid);
-            }
-            return textures[uuid];
-        }
-
-        let geometry, material;
-        const meta = {
-            textures: textures,
-            geometries: geometries,
-            materials: materials,
-        };
         const dependencies: {[uuid: string]: Behavior} = {};
+        const meta = {textures, geometries, materials};
+
+        let object, geometry, material;
 
         switch (data.type) {
             case 'QuarksPrefab':
                 object = QuarksPrefab.fromJSON(data);
+
                 break;
+
             case 'ParticleEmitter':
                 object = ParticleSystem.fromJSON(data.ps, meta as any, dependencies).emitter;
+
                 break;
+
             case 'Scene':
                 object = new Scene();
+
                 if (data.background !== undefined) {
                     if (Number.isInteger(data.background)) {
                         object.background = new Color(data.background);
                     } else {
-                        object.background = getTexture(data.background);
+                        object.background = this.resolveTexture(textures, data.background);
                     }
                 }
 
                 if (data.environment !== undefined) {
-                    object.environment = getTexture(data.environment);
+                    object.environment = this.resolveTexture(textures, data.environment);
                 }
 
                 if (data.fog !== undefined) {
@@ -241,16 +211,14 @@ export class QuarksLoader extends ObjectLoader {
 
             case 'LightProbe':
                 object = new LightProbe();
-                if (data.sh !== undefined) {
-                    object.sh = new SphericalHarmonics3().fromArray(data.sh);
-                }
+
+                if (data.sh !== undefined) object.sh = new SphericalHarmonics3().fromArray(data.sh);
 
                 break;
 
             case 'SkinnedMesh':
-                geometry = getGeometry(data.geometry);
-                material = getMaterial(data.material);
-
+                geometry = this.resolveGeometry(geometries, data.geometry);
+                material = this.resolveMaterial(materials, data.material);
                 object = new SkinnedMesh(geometry, material);
 
                 if (data.bindMode !== undefined) object.bindMode = data.bindMode;
@@ -260,32 +228,36 @@ export class QuarksLoader extends ObjectLoader {
                 break;
 
             case 'Mesh':
-                geometry = getGeometry(data.geometry);
-                material = getMaterial(data.material);
-
+                geometry = this.resolveGeometry(geometries, data.geometry);
+                material = this.resolveMaterial(materials, data.material);
                 object = new Mesh(geometry, material);
 
                 break;
 
             case 'InstancedMesh': {
-                geometry = getGeometry(data.geometry);
-                material = getMaterial(data.material);
+                geometry = this.resolveGeometry(geometries, data.geometry);
+                material = this.resolveMaterial(materials, data.material);
+
                 const count = data.count;
                 const instanceMatrix = data.instanceMatrix;
                 const instanceColor = data.instanceColor;
 
                 object = new InstancedMesh(geometry, material, count);
                 object.instanceMatrix = new InstancedBufferAttribute(new Float32Array(instanceMatrix.array), 16);
-                if (instanceColor !== undefined)
+
+                if (instanceColor !== undefined) {
                     object.instanceColor = new InstancedBufferAttribute(
                         new Float32Array(instanceColor.array),
                         instanceColor.itemSize
                     );
+                }
+
                 break;
             }
+
             case 'BatchedMesh':
-                geometry = getGeometry(data.geometry);
-                material = getMaterial(data.material);
+                geometry = this.resolveGeometry(geometries, data.geometry);
+                material = this.resolveMaterial(materials, data.material);
 
                 object = new BatchedMesh(
                     data.maxGeometryCount,
@@ -293,15 +265,16 @@ export class QuarksLoader extends ObjectLoader {
                     data.maxIndexCount,
                     material as Material
                 );
+
                 object.geometry = geometry;
                 object.perObjectFrustumCulled = data.perObjectFrustumCulled;
                 object.sortObjects = data.sortObjects;
 
                 (object as any)._drawRanges = data.drawRanges;
                 (object as any)._reservedRanges = data.reservedRanges;
-
                 (object as any)._visibility = data.visibility;
                 (object as any)._active = data.active;
+
                 (object as any)._bounds = data.bounds.map((bound: any) => {
                     const box = new Box3();
                     box.min.fromArray(bound.boxMin);
@@ -314,7 +287,6 @@ export class QuarksLoader extends ObjectLoader {
                     return {
                         boxInitialized: bound.boxInitialized,
                         box: box,
-
                         sphereInitialized: bound.sphereInitialized,
                         sphere: sphere,
                     };
@@ -323,11 +295,9 @@ export class QuarksLoader extends ObjectLoader {
                 (object as any)._maxGeometryCount = data.maxGeometryCount;
                 (object as any)._maxVertexCount = data.maxVertexCount;
                 (object as any)._maxIndexCount = data.maxIndexCount;
-
                 (object as any)._geometryInitialized = data.geometryInitialized;
                 (object as any)._geometryCount = data.geometryCount;
-
-                (object as any)._matricesTexture = getTexture(data.matricesTexture.uuid);
+                (object as any)._matricesTexture = this.resolveTexture(textures, data.matricesTexture.uuid);
 
                 break;
 
@@ -337,28 +307,40 @@ export class QuarksLoader extends ObjectLoader {
                 break;
 
             case 'Line':
-                object = new Line(getGeometry(data.geometry), getMaterial(data.material));
+                object = new Line(
+                    this.resolveGeometry(geometries, data.geometry),
+                    this.resolveMaterial(materials, data.material)
+                );
 
                 break;
 
             case 'LineLoop':
-                object = new LineLoop(getGeometry(data.geometry), getMaterial(data.material));
+                object = new LineLoop(
+                    this.resolveGeometry(geometries, data.geometry),
+                    this.resolveMaterial(materials, data.material)
+                );
 
                 break;
 
             case 'LineSegments':
-                object = new LineSegments(getGeometry(data.geometry), getMaterial(data.material));
+                object = new LineSegments(
+                    this.resolveGeometry(geometries, data.geometry),
+                    this.resolveMaterial(materials, data.material)
+                );
 
                 break;
 
             case 'PointCloud':
             case 'Points':
-                object = new Points(getGeometry(data.geometry), getMaterial(data.material));
+                object = new Points(
+                    this.resolveGeometry(geometries, data.geometry),
+                    this.resolveMaterial(materials, data.material)
+                );
 
                 break;
 
             case 'Sprite':
-                object = new Sprite(getMaterial(data.material) as SpriteMaterial);
+                object = new Sprite(this.resolveMaterial(materials, data.material) as SpriteMaterial);
 
                 break;
 
@@ -382,12 +364,11 @@ export class QuarksLoader extends ObjectLoader {
 
         if (data.matrix !== undefined) {
             object.matrix.fromArray(data.matrix);
+
             if (data.matrixAutoUpdate !== undefined) object.matrixAutoUpdate = data.matrixAutoUpdate;
             if (object.matrixAutoUpdate) {
                 object.matrix.decompose(object.position, object.quaternion, object.scale);
-                if (isNaN(object.quaternion.x)) {
-                    object.quaternion.set(0, 0, 0, 1);
-                }
+                if (isNaN(object.quaternion.x)) object.quaternion.set(0, 0, 0, 1);
             }
         } else {
             if (data.position !== undefined) object.position.fromArray(data.position);
@@ -426,9 +407,9 @@ export class QuarksLoader extends ObjectLoader {
 
         if (data.animations !== undefined) {
             const objectAnimations = data.animations;
+
             for (let i = 0; i < objectAnimations.length; i++) {
                 const uuid = objectAnimations[i];
-
                 object.animations.push(animations[uuid]);
             }
         }
@@ -437,13 +418,13 @@ export class QuarksLoader extends ObjectLoader {
             if (data.autoUpdate !== undefined) (object as any).autoUpdate = data.autoUpdate;
 
             const levels = data.levels;
+
             for (let l = 0; l < levels.length; l++) {
                 const level = levels[l];
                 const child = object.getObjectByProperty('uuid', level.object);
 
                 if (child !== undefined) {
-                    // @ts-ignore
-                    object.addLevel(child, level.distance);
+                    (object as LOD).addLevel(child, level.distance);
                 }
             }
         } else if (data.type === 'QuarksPrefab') {
@@ -451,5 +432,50 @@ export class QuarksLoader extends ObjectLoader {
         }
 
         return object;
+    }
+
+    private resolveGeometry(geometries: {[uuid: string]: BufferGeometry}, name: string): BufferGeometry {
+        if (geometries[name] === undefined) {
+            console.warn('THREE.ObjectLoader: Undefined geometry', name);
+        }
+
+        return geometries[name];
+    }
+
+    private resolveMaterial(
+        materials: {[uuid: string]: Material},
+        name: string | string[] | undefined
+    ): Material | Material[] | undefined {
+        if (name === undefined) return undefined;
+
+        if (Array.isArray(name)) {
+            const array: Material[] = [];
+
+            for (let i = 0, l = name.length; i < l; i++) {
+                const uuid = name[i];
+
+                if (materials[uuid] === undefined) {
+                    console.warn('THREE.ObjectLoader: Undefined material', uuid);
+                }
+
+                array.push(materials[uuid]);
+            }
+
+            return array;
+        }
+
+        if (materials[name] === undefined) {
+            console.warn('THREE.ObjectLoader: Undefined material', name);
+        }
+
+        return materials[name];
+    }
+
+    private resolveTexture(textures: {[uuid: string]: Texture}, uuid: string): Texture {
+        if (textures[uuid] === undefined) {
+            console.warn('THREE.ObjectLoader: Undefined texture', uuid);
+        }
+
+        return textures[uuid];
     }
 }

--- a/packages/three.quarks/src/QuarksPrefab.ts
+++ b/packages/three.quarks/src/QuarksPrefab.ts
@@ -1,27 +1,34 @@
-import {IPrefab, IAnimationData} from 'quarks.core';
-import { Group, Object3D, Clock, AnimationClip, AnimationMixer, AnimationAction, LoopOnce } from 'three';
-import { BatchedRenderer } from './BatchedRenderer';
-import { ParticleEmitter } from './ParticleEmitter';
+import {IAnimationData, IPrefab} from 'quarks.core';
+import {AnimationAction, AnimationClip, AnimationMixer, Clock, Group, LoopOnce, Object3D} from 'three';
+import {ParticleEmitter} from './ParticleEmitter';
 
 /**
- * Interface for animation data
+ * Interface for animation data.
  */
 interface AnimationData extends IAnimationData {
-    /** Start time in seconds */
-    startTime: number;
-    /** Duration in seconds */
-    duration: number;
-    /** Target object */
+    /**
+     * Target object.
+     */
     target: Object3D;
-    /** Type of animation */
+    /**
+     * Type of animation.
+     */
     type: 'three' | 'ps';
-    /** Animation clip for Three.js animations */
+    /**
+     * Animation clip for Three.js animations.
+     */
     clip?: AnimationClip;
-    /** Mixer for Three.js animations */
+    /**
+     * Mixer for Three.js animations.
+     */
     mixer?: AnimationMixer;
-    /** Action for Three.js animations */
+    /**
+     * Action for Three.js animations.
+     */
     action?: AnimationAction;
-    /** Loop the animation */
+    /**
+     * Whether to loop the animation.
+     */
     loop?: boolean;
 }
 
@@ -34,66 +41,69 @@ interface AnimationJSON {
     loop: boolean;
 }
 
+type AnimationTiming = {
+    isActive: boolean;
+    isEnded: boolean;
+    isStartFrame: boolean;
+};
+
 /**
  * AnimationPrefab is a class that manages multiple animations in a unified timeline.
  * It can handle both Three.js animations and particle system animations from three.quarks.
  */
 export class QuarksPrefab extends Group implements IPrefab {
-    type = 'QuarksPrefab';
-    public animationData: Array<AnimationData> = [];
-    public isPlaying: boolean = false;
-    public currentTime: number = -0.00001;
-    public timeScale: number = 1;
-    public duration: number = 0;
+    readonly type = 'QuarksPrefab';
 
-    private _clock: Clock;
-    private _mixers: Map<Object3D, AnimationMixer> = new Map();
-    private _batchedRenderer?: BatchedRenderer;
-    private _tempAnimationJSON: Array<AnimationJSON> = [];
+    private readonly _clock = new Clock(true);
+    private readonly _mixers: Map<Object3D, AnimationMixer> = new Map();
+
+    private readonly _mixersToUpdate: Set<AnimationMixer> = new Set();
+    private readonly _animationTiming: AnimationTiming = {
+        isActive: false,
+        isEnded: false,
+        isStartFrame: false,
+    };
+
+    readonly animationData: AnimationData[] = [];
+    private _animationJSON: AnimationJSON[] = [];
+
+    isPlaying: boolean = false;
+    currentTime: number = -0.00001;
+    timeScale: number = 1;
+    duration: number = 0;
+
     /**
-     * Creates a new AnimationPrefab
+     * Creates a new AnimationPrefab.
      */
     constructor() {
         super();
-        this._clock = new Clock(true);
-    }
-
-    private registerBatchedRenderer(renderer: BatchedRenderer): void {
-        this._batchedRenderer = renderer;
     }
 
     /**
-     * Gets or creates an AnimationMixer for a target object
-     * @param target The target object that needs a mixer
-     * @returns The AnimationMixer for the target
+     * Add a Three.js animation.
+     * @param target - The target object to animate.
+     * @param clip - The animation clip.
+     * @param startTime - When to start the animation in seconds.
+     * @param duration - Duration of the animation in seconds.
+     * @param loop - Whether to loop the animation.
+     * @returns The animation data.
      */
-    private getOrCreateMixer(target: Object3D): AnimationMixer {
-        if (!this._mixers.has(target)) {
-            const mixer = new AnimationMixer(target);
-            this._mixers.set(target, mixer);
-        }
-        return this._mixers.get(target)!;
-    }
-
-    /**
-     * Add a Three.js animation
-     * @param target The target object to animate
-     * @param clip The animation clip
-     * @param startTime When to start the animation in seconds
-     * @param duration Duration of the animation in seconds
-     * @param loop Whether to loop the animation
-     * @returns The ID of the added animation
-     */
-    addThreeAnimation(target: Object3D, clip: AnimationClip, startTime: number = 0, duration: number = clip.duration, loop: boolean = false): AnimationData {
+    addThreeAnimation(
+        target: Object3D,
+        clip: AnimationClip,
+        startTime: number = 0,
+        duration: number = clip.duration,
+        loop: boolean = false
+    ): AnimationData {
         const mixer = this.getOrCreateMixer(target);
         const action = mixer.clipAction(clip);
-        
+
         if (!loop) {
             action.setLoop(LoopOnce, 1);
             action.clampWhenFinished = true;
         }
-        
-        const data: AnimationData = {
+
+        const animation: AnimationData = {
             startTime,
             duration,
             type: 'three',
@@ -101,48 +111,52 @@ export class QuarksPrefab extends Group implements IPrefab {
             target,
             clip,
             mixer,
-            action
+            action,
         };
-        this.animationData.push(data);
 
+        this.animationData.push(animation);
         this.updateDuration();
-        return data;
+
+        return animation;
     }
 
     /**
-     * Add a particle system animation
-     * @param emitter The particle emitter
-     * @param startTime When to start the animation in seconds
-     * @param duration Duration of the animation in seconds
-     * @param loop Whether to loop the animation
-     * @returns The ID of the added animation
+     * Add a particle system animation.
+     * @param emitter - The particle emitter.
+     * @param startTime - When to start the animation in seconds.
+     * @param duration - Duration of the animation in seconds.
+     * @param loop - Whether to loop the animation.
+     * @returns The animation data.
      */
-    addParticleSystemAnimation(emitter: ParticleEmitter, startTime: number = 0, duration: number = 0, loop: boolean = false): AnimationData {
-        
+    addParticleSystemAnimation(
+        emitter: ParticleEmitter,
+        startTime: number = 0,
+        duration: number = 0,
+        loop: boolean = false
+    ): AnimationData {
         // If duration is not specified, use the emitter's system duration
-        if (duration <= 0) {
-            duration = emitter.system.duration;
-        }
-        
-        const data: AnimationData = {
+        const animationDuration = duration <= 0 ? emitter.system.duration : duration;
+
+        const animation: AnimationData = {
             startTime,
-            duration,
+            duration: animationDuration,
             type: 'ps',
             loop,
-            target: emitter
+            target: emitter,
         };
-        this.animationData.push(data);
+
+        this.animationData.push(animation);
 
         // Pause the particle system initially
         this.pause();
-        
         this.updateDuration();
-        return data;
+
+        return animation;
     }
 
     /**
-     * Remove an animation by its index
-     * @param index The index of the animation to remove
+     * Remove an animation by its index.
+     * @param index - The index of the animation to remove.
      */
     removeAnimation(index: number): void {
         this.animationData.splice(index, 1);
@@ -150,7 +164,7 @@ export class QuarksPrefab extends Group implements IPrefab {
     }
 
     /**
-     * Start playing all animations
+     * Start playing all animations.
      */
     play(): void {
         if (this.isPlaying) return;
@@ -158,240 +172,298 @@ export class QuarksPrefab extends Group implements IPrefab {
     }
 
     /**
-     * Pause all animations
+     * Pause all animations.
      */
     pause(): void {
         if (!this.isPlaying) return;
+
         this.isPlaying = false;
-        
-        // Pause all particle systems
-        this.animationData.forEach(anim => {
-            if (anim.target) {
-                if (anim.type === 'ps' && !(anim.target as ParticleEmitter).system.paused) {
-                    (anim.target as ParticleEmitter).system.pause();
-                } else if (anim.type === 'three' && anim.action && anim.action.isRunning()) {
-                    anim.action.paused = true;
-                }
+
+        for (const animation of this.animationData) {
+            if (!animation.target) continue;
+
+            const target = animation.target as ParticleEmitter;
+
+            if (animation.type === 'ps' && !target.system.paused) {
+                target.system.pause();
+                continue;
             }
-        });
+
+            if (animation.type === 'three' && animation.action && animation.action.isRunning()) {
+                animation.action.paused = true;
+            }
+        }
     }
 
     /**
-     * Stop all animations and reset to the beginning
+     * Stop and reset all animations.
      */
     stop(): void {
         this.pause();
         this.currentTime = -0.00001;
-        
-        // Reset all animations
-        this.animationData.forEach(anim => {
-            if (anim.type === 'ps' && anim.target) {
-                (anim.target as ParticleEmitter).system.stop();
-            } else if (anim.type === 'three' && anim.mixer && anim.action) {
-                anim.action.reset();
+
+        for (const animation of this.animationData) {
+            if (animation.type === 'ps' && animation.target) {
+                (animation.target as ParticleEmitter).system.stop();
+                continue;
             }
-        });
+
+            if (animation.type === 'three' && animation.mixer && animation.action) {
+                animation.action.reset();
+            }
+        }
     }
 
     /**
-     * Update animations on each frame
-     * @param forceDelta Optional delta time to force update
+     * Update animations per frame.
+     * @param forceDelta - Optional delta time to force an update.
      */
     update(forceDelta?: number): void {
         if (!this.isPlaying) return;
-        
+
         const delta = forceDelta !== undefined ? forceDelta : this._clock.getDelta();
         this.currentTime += delta * this.timeScale;
-        
-        // Check if animation has ended
-        if (this.currentTime > this.duration) {
-            // Reset or stop
-            this.stop();    
-        }
-        
-        const currentMixers = new Set<AnimationMixer>();
-        // Update each animation
-        this.animationData.forEach(anim => {
-            const { startTime, duration, type, loop, target, action, mixer } = anim;
-            
-            // Check if this animation should be active
-            const animationEndTime = startTime + duration;
-            const isTimeToStart = this.currentTime >= startTime;
-            const isTimeToEnd = this.currentTime > animationEndTime;
-            const isStartFrame = Math.abs(this.currentTime - startTime) < delta;
-            
-            if (type === 'three' && action && mixer) {
-                if (isTimeToStart && !isTimeToEnd) {
-                    if (isStartFrame) {
-                        action.reset();
-                        action.play();
-                    } else {
-                        // Start or update the animation
-                        if (action.paused) {
-                            action.paused = false;
-                            action.play();
-                        }
-                    }
-                    
-                    // Calculate local time for this animation
-                    const localTime = this.currentTime - startTime;
-                    const normalizedTime = localTime % duration;
-                    
-                    currentMixers.add(mixer);
-                } else if (isTimeToEnd) {
-                    action.paused = true;
-                }
-            } else if (type === 'ps' && target) {
-                if (isTimeToStart && !isTimeToEnd) {
-                    // Particle systems need to be restarted at their start time
-                    if (isStartFrame) {
-                        (anim.target as ParticleEmitter).system.restart();
-                    }
-                } else if (isTimeToEnd) {
-                    (anim.target as ParticleEmitter).system.endEmit();
-                }
-            }
-        });
 
-        currentMixers.forEach(mixer => {
+        // Reset or stop if the animation has ended
+        if (this.currentTime > this.duration) {
+            this.stop();
+        }
+
+        // Clear the scratch set before collecting mixer updates
+        this._mixersToUpdate.clear();
+
+        for (const animation of this.animationData) {
+            const timing = this.writeAnimationTiming(animation, delta);
+
+            if (animation.type === 'three') {
+                // Queues active mixers so each shared target mixer updates once per frame.
+                this.updateThreeAnimation(animation, timing);
+                continue;
+            }
+
+            this.updateParticleSystemAnimation(animation, timing);
+        }
+
+        for (const mixer of this._mixersToUpdate) {
             mixer.update(delta);
-        });
+        }
     }
 
     /**
-     * Set the animation time
-     * @param time Time in seconds
+     * Set the animation time.
+     * @param time - Time in seconds.
      */
     setTime(time: number): void {
         const previousTime = this.currentTime;
         this.currentTime = time;
-        
-        // Handle updates for each animation
-        this.animationData.forEach(anim => {
-            const { startTime, duration, type, target, action, mixer } = anim;
-            
-            if (type === 'three' && action && mixer) {
-                // Reset and update the animation to the correct time
-                action.reset();
-                
-                if (time >= startTime && time < startTime + duration) {
-                    const localTime = time - startTime;
-                    action.time = localTime;
-                    action.play();
-                    mixer.update(0);
-                    action.paused = !this.isPlaying;
-                }
-            } 
-            else if (type === 'ps' && target) {
-                // Handle particle system time setting
-                if (time >= startTime && time < startTime + duration) {
-                    if (previousTime < startTime || previousTime >= startTime + duration) {
-                        // Particle system needs to be restarted if we're jumping into its time range
-                        (target as ParticleEmitter).system.restart();
-                    }
-                } else {
-                    // Outside the time range - stop the particle system
-                    (target as ParticleEmitter).system.endEmit();
-                }
+
+        for (const animation of this.animationData) {
+            if (animation.type === 'three') {
+                this.setThreeAnimationTime(animation, time);
+                continue;
             }
-        });
+
+            this.setParticleSystemAnimationTime(animation, time, previousTime);
+        }
     }
 
     /**
-     * Get the total duration of all animations
+     * Get the total duration of all animations.
      */
     getDuration(): number {
         return this.duration;
     }
 
     /**
-     * Update the total duration based on all animations
-     */
-    private updateDuration(): void {
-        let maxDuration = 0;
-        
-        this.animationData.forEach(anim => {
-            const endTime = anim.startTime + anim.duration;
-            if (endTime > maxDuration) {
-                maxDuration = endTime;
-            }
-        });
-        
-        this.duration = maxDuration;
-    }
-
-    /**
-     * Find objects in the scene by their UUID
-     * @param root The root object to search from
+     * Find objects in the scene by their UUID.
+     * @param root - The root object to search from.
      */
     resolveReferences(root: Object3D): void {
-        // Find all objects by UUID and update the references
-        this._tempAnimationJSON.forEach(animJson => {
-            let target: Object3D | undefined;
-            
-            // Find the target
-            root.traverse(object => {
-                if (object.uuid === animJson.targetUUID) {
-                    target = object;
-                }
-            });
-            
-            if (target) {
-                // If it's a Three.js animation, find the clip and create the mixer
-                if (animJson.type === 'three' && animJson.clipUUID) {
-                    // Find the animation clip
-                    let clip: AnimationClip | undefined;
-                    
-                    if (target.animations) {
-                        clip = target.animations.find(c => c.uuid === animJson.clipUUID);
-                    }
+        if (this._animationJSON.length === 0) return;
 
-                    if (clip) {
-                        this.addThreeAnimation(target, clip, animJson.startTime, animJson.duration, animJson.loop);
-                    }
-                } else if (animJson.type === 'ps') {
-                    this.addParticleSystemAnimation(target as ParticleEmitter, animJson.startTime, animJson.duration, animJson.loop);
-                }
-            }
-        });
-            
+        const objectsByUuid = new Map<string, Object3D>();
+        root.traverse((object) => objectsByUuid.set(object.uuid, object));
+
+        for (const json of this._animationJSON) {
+            const target = objectsByUuid.get(json.targetUUID);
+            if (!target) continue;
+
+            this.addAnimationFromJSON(json, target);
+        }
+
         this.updateDuration();
-        this._tempAnimationJSON = [];
+        this._animationJSON.length = 0;
     }
 
     /**
-     * Convert to JSON for serialization
-     * @returns JSON object
+     * Convert to JSON for serialization.
+     * @returns The JSON object.
      */
     toJSON(): any {
         const json = super.toJSON();
-        
-        // Add animations data
-        (json.object as any).animationData = this.animationData.map(anim => ({
-            startTime: anim.startTime,
-            duration: anim.duration,
-            type: anim.type,
-            targetUUID: anim.target.uuid,
-            clipUUID: anim.clip?.uuid,
-            loop: anim.loop
+
+        (json.object as any).animationData = this.animationData.map((animation) => ({
+            startTime: animation.startTime,
+            duration: animation.duration,
+            type: animation.type,
+            targetUUID: animation.target.uuid,
+            clipUUID: animation.clip?.uuid,
+            loop: animation.loop,
         }));
-        
+
         return json;
     }
 
     /**
-     * Create an AnimationPrefab from JSON data
-     * @param json The JSON data
-     * @returns A new AnimationPrefab instance
+     * Create an AnimationPrefab from JSON data.
+     * @param json - The JSON data.
+     * @returns A new QuarksPrefab instance.
      */
     static fromJSON(json: any): QuarksPrefab {
         const prefab = new QuarksPrefab();
-        
-        // Add animations
+
         if (json.animationData) {
-            prefab._tempAnimationJSON = json.animationData;
+            prefab._animationJSON = json.animationData;
         }
-        
+
         return prefab;
+    }
+
+    /**
+     * Gets or creates an AnimationMixer for a target object.
+     * @param target - The target object that needs a mixer.
+     * @returns The AnimationMixer for the target.
+     */
+    private getOrCreateMixer(target: Object3D): AnimationMixer {
+        if (!this._mixers.has(target)) {
+            this._mixers.set(target, new AnimationMixer(target));
+        }
+
+        return this._mixers.get(target)!;
+    }
+
+    /**
+     * Update the total duration based on all animations.
+     */
+    private updateDuration(): void {
+        let maxDuration = 0;
+
+        for (const animation of this.animationData) {
+            const endTime = animation.startTime + animation.duration;
+
+            if (endTime > maxDuration) {
+                maxDuration = endTime;
+            }
+        }
+
+        this.duration = maxDuration;
+    }
+
+    private writeAnimationTiming(animation: AnimationData, delta: number): AnimationTiming {
+        const animationEndTime = animation.startTime + animation.duration;
+        const hasStarted = this.currentTime >= animation.startTime;
+        const isEnded = this.currentTime > animationEndTime;
+
+        this._animationTiming.isActive = hasStarted && !isEnded;
+        this._animationTiming.isEnded = isEnded;
+        this._animationTiming.isStartFrame = Math.abs(this.currentTime - animation.startTime) < delta;
+
+        return this._animationTiming;
+    }
+
+    private updateThreeAnimation(animation: AnimationData, timing: AnimationTiming): void {
+        if (!animation.action || !animation.mixer) return;
+
+        if (timing.isActive) {
+            if (timing.isStartFrame) {
+                animation.action.reset();
+                animation.action.play();
+            } else if (animation.action.paused) {
+                animation.action.paused = false;
+                animation.action.play();
+            }
+
+            this._mixersToUpdate.add(animation.mixer);
+            return;
+        }
+
+        if (timing.isEnded) {
+            animation.action.paused = true;
+        }
+    }
+
+    private updateParticleSystemAnimation(animation: AnimationData, timing: AnimationTiming): void {
+        const target = animation.target as ParticleEmitter;
+
+        if (timing.isActive) {
+            // Particle systems need to be restarted at their start time.
+            if (timing.isStartFrame) {
+                target.system.restart();
+            }
+
+            return;
+        }
+
+        if (timing.isEnded) {
+            target.system.endEmit();
+        }
+    }
+
+    private setThreeAnimationTime(animation: AnimationData, time: number): void {
+        if (!animation.action || !animation.mixer) return;
+
+        // Reset and update the animation to the correct time.
+        animation.action.reset();
+
+        if (this.containsAnimationTime(animation, time)) {
+            animation.action.time = time - animation.startTime;
+            animation.action.play();
+            animation.mixer.update(0);
+            animation.action.paused = !this.isPlaying;
+        }
+    }
+
+    private setParticleSystemAnimationTime(animation: AnimationData, time: number, previousTime: number): void {
+        if (!animation.target) return;
+
+        const target = animation.target as ParticleEmitter;
+
+        if (!this.containsAnimationTime(animation, time)) {
+            // Outside the time range - stop the particle system.
+            target.system.endEmit();
+            return;
+        }
+
+        if (!this.containsAnimationTime(animation, previousTime)) {
+            // Particle systems need a restart when seeking into their time range.
+            target.system.restart();
+        }
+    }
+
+    private containsAnimationTime(animation: AnimationData, time: number): boolean {
+        // Seeking treats the exact end time as outside the animation range.
+        return time >= animation.startTime && time < animation.startTime + animation.duration;
+    }
+
+    private addAnimationFromJSON(json: AnimationJSON, target: Object3D): void {
+        switch (json.type) {
+            case 'three':
+                this.addThreeAnimationFromJSON(json, target);
+                return;
+            case 'ps':
+                this.addParticleSystemAnimation(target as ParticleEmitter, json.startTime, json.duration, json.loop);
+                return;
+            default:
+                json.type satisfies never;
+        }
+    }
+
+    private addThreeAnimationFromJSON(json: AnimationJSON, target: Object3D): void {
+        if (!json.clipUUID) return;
+
+        const matchingClip = target.animations?.find((clip) => clip.uuid === json.clipUUID);
+        if (!matchingClip) return;
+
+        this.addThreeAnimation(target, matchingClip, json.startTime, json.duration, json.loop);
     }
 }

--- a/packages/three.quarks/src/QuarksUtil.ts
+++ b/packages/three.quarks/src/QuarksUtil.ts
@@ -1,12 +1,15 @@
 import {Object3D} from 'three';
-import {ParticleEmitter} from './ParticleEmitter';
 import {BatchedRenderer} from './BatchedRenderer';
+import {ParticleEmitter} from './ParticleEmitter';
 
+/**
+ * Convenience helpers for applying common particle-system operations to Object3D trees.
+ */
 export class QuarksUtil {
     /**
-     * Run a function on all particle emitters in the object and the object's children.
-     * @param obj
-     * @param func
+     * Runs a callback for every particle emitter in an object tree.
+     * @param obj - Root object to traverse.
+     * @param func - Callback invoked for each particle emitter.
      */
     static runOnAllParticleEmitters(obj: Object3D, func: (ps: ParticleEmitter) => void) {
         obj.traverse((child) => {
@@ -14,77 +17,63 @@ export class QuarksUtil {
                 func(child as ParticleEmitter);
             }
         });
-        if (obj.type === 'ParticleEmitter') {
-            func(obj as ParticleEmitter);
-        }
     }
 
     /**
-     * Add all particle systems in the object and the object's children to the batch renderer.
-     * @param obj
-     * @param batchRenderer
+     * Adds every particle system in an object tree to a batched renderer.
+     * @param obj - Root object to traverse.
+     * @param batchRenderer - Renderer that receives each particle system.
      */
     static addToBatchRenderer(obj: Object3D, batchRenderer: BatchedRenderer) {
-        QuarksUtil.runOnAllParticleEmitters(obj, (ps) => {
-            batchRenderer.addSystem(ps.system);
-        });
+        QuarksUtil.runOnAllParticleEmitters(obj, (ps) => batchRenderer.addSystem(ps.system));
     }
 
     /**
-     * Start playing all particle systems in the object and the object's children.
-     * @param obj
+     * Starts every particle system in an object tree.
+     * @param obj - Root object to traverse.
      */
     static play(obj: Object3D) {
-        QuarksUtil.runOnAllParticleEmitters(obj, (ps) => {
-            ps.system.play();
-        });
+        QuarksUtil.runOnAllParticleEmitters(obj, (ps) => ps.system.play());
     }
 
     /**
-     * Stop all particle systems in the object and the object's children.
-     * this call will clear all existing particles.
-     * @param obj
+     * Stops every particle system in an object tree and clears existing particles.
+     * @param obj - Root object to traverse.
      */
     static stop(obj: Object3D) {
-        QuarksUtil.runOnAllParticleEmitters(obj, (ps) => {
-            ps.system.stop();
-        });
-    }
-
-    static setAutoDestroy(obj: Object3D, value: boolean) {
-        QuarksUtil.runOnAllParticleEmitters(obj, (ps) => {
-            ps.system.autoDestroy = value;
-        });
+        QuarksUtil.runOnAllParticleEmitters(obj, (ps) => ps.system.stop());
     }
 
     /**
-     * Stop emit new particles from all particle systems and
-     * keep simulating the existing particles in the object and the object's children.
-     * @param obj
+     * Sets auto-destroy on every particle system in an object tree.
+     * @param obj - Root object to traverse.
+     * @param value - Whether each particle system should destroy itself after finishing.
+     */
+    static setAutoDestroy(obj: Object3D, value: boolean) {
+        QuarksUtil.runOnAllParticleEmitters(obj, (ps) => (ps.system.autoDestroy = value));
+    }
+
+    /**
+     * Stops emission for every particle system in an object tree while keeping existing particles alive.
+     * @param obj - Root object to traverse.
      */
     static endEmit(obj: Object3D) {
-        QuarksUtil.runOnAllParticleEmitters(obj, (ps) => {
-            ps.system.endEmit();
-        });
+        QuarksUtil.runOnAllParticleEmitters(obj, (ps) => ps.system.endEmit());
     }
 
     /**
-     * Restart all particle systems in the object and the object's children.
-     * @param obj
+     * Restarts every particle system in an object tree.
+     * @param obj - Root object to traverse.
      */
     static restart(obj: Object3D) {
-        QuarksUtil.runOnAllParticleEmitters(obj, (ps) => {
-            ps.system.restart();
-        });
+        QuarksUtil.runOnAllParticleEmitters(obj, (ps) => ps.system.restart());
     }
 
     /**
-     * Pause the simulation of all particle systems in the object and the object's children.
-     * @param obj
+     * Pauses every particle system in an object tree.
+     * @param obj - Root object to traverse.
      */
     static pause(obj: Object3D) {
-        QuarksUtil.runOnAllParticleEmitters(obj, (ps) => {
-            ps.system.pause();
-        });
+        QuarksUtil.runOnAllParticleEmitters(obj, (ps) => ps.system.pause());
     }
 }

--- a/packages/three.quarks/src/SpriteBatch.ts
+++ b/packages/three.quarks/src/SpriteBatch.ts
@@ -1,35 +1,61 @@
 import {
-    DynamicDrawUsage,
-    InstancedBufferAttribute,
-    InstancedBufferGeometry,
-    WebGLRenderer,
-    Uniform,
-    MeshStandardMaterial,
-    ShaderMaterial,
-    Scene,
-    PerspectiveCamera,
-    MeshPhysicalMaterial, Object3D,
-} from 'three';
-import {
+    IParticleSystem,
+    Matrix3,
+    Matrix4,
+    Quaternion,
+    SpriteParticle,
+    StretchedBillBoardSettings,
     Vector2,
     Vector3,
     Vector4,
-    Quaternion,
-    Matrix3,
-    SpriteParticle, StretchedBillBoardSettings} from 'quarks.core';
-import particle_frag from './shaders/particle_frag.glsl';
-import particle_physics_frag from './shaders/particle_physics_frag.glsl';
-import particle_vert from './shaders/particle_vert.glsl';
-import local_particle_vert from './shaders/local_particle_vert.glsl';
-import local_particle_physics_vert from './shaders/local_particle_physics_vert.glsl';
-import stretched_bb_particle_vert from './shaders/stretched_bb_particle_vert.glsl';
-import {getMaterialUVChannelName} from './util/ThreeUtil';
+} from 'quarks.core';
+import {
+    DynamicDrawUsage,
+    InstancedBufferAttribute,
+    InstancedBufferGeometry,
+    MeshPhysicalMaterial,
+    MeshStandardMaterial,
+    PerspectiveCamera,
+    Scene,
+    ShaderMaterial,
+    Uniform,
+    WebGLRenderer,
+} from 'three';
+
 import {VFXBatchSettings} from './BatchedRenderer';
 import {RenderMode, VFXBatch} from './VFXBatch';
 import {ParticleMeshPhysicsMaterial, ParticleMeshStandardMaterial} from './materials/ParticleMaterials';
+import local_particle_physics_vert from './shaders/local_particle_physics_vert.glsl';
+import local_particle_vert from './shaders/local_particle_vert.glsl';
+import particle_frag from './shaders/particle_frag.glsl';
+import particle_physics_frag from './shaders/particle_physics_frag.glsl';
+import particle_vert from './shaders/particle_vert.glsl';
+import stretched_bb_particle_vert from './shaders/stretched_bb_particle_vert.glsl';
+import {getMaterialUVChannelName, updateBufferAttribute} from './util/ThreeUtil';
+
+const SUPPORTED_RENDER_MODES: ReadonlySet<RenderMode> = new Set([
+    RenderMode.Mesh,
+    RenderMode.BillBoard,
+    RenderMode.StretchedBillBoard,
+    RenderMode.HorizontalBillBoard,
+    RenderMode.VerticalBillBoard,
+]);
+
+type onBeforeRenderCallback = (renderer: WebGLRenderer, scene: Scene, camera: PerspectiveCamera) => void;
+
+type SpriteBatchUpdateContext = {
+    renderMode: RenderMode;
+    worldSpace: boolean;
+    emitterMatrix: Matrix4;
+    emitterRotation: Quaternion;
+    emitterScale: Vector3;
+    velocityBuffer?: InstancedBufferAttribute;
+    speedFactor: number;
+    lengthFactor: number;
+};
 
 /**
- * A VFX batch that render sprites in a batch.
+ * A VFX batch that renders sprites.
  */
 export class SpriteBatch extends VFXBatch {
     declare geometry: InstancedBufferGeometry;
@@ -41,7 +67,23 @@ export class SpriteBatch extends VFXBatch {
     private uvTileBuffer!: InstancedBufferAttribute;
     private velocityBuffer?: InstancedBufferAttribute;
 
+    private readonly _vA: Vector3 = new Vector3();
+    private readonly _vB: Vector3 = new Vector3();
+    private readonly _vC: Vector3 = new Vector3();
+    private readonly _qA: Quaternion = new Quaternion();
+    private readonly _qB: Quaternion = new Quaternion();
+    private readonly _qC: Quaternion = new Quaternion();
+    private readonly _mA: Matrix3 = new Matrix3();
+    private readonly _mB: Matrix3 = new Matrix3();
+
+    private readonly _visibleSystems: IParticleSystem[] = [];
+    private readonly _updateContext: SpriteBatchUpdateContext = {} as SpriteBatchUpdateContext;
+
     constructor(settings: VFXBatchSettings) {
+        if (!SUPPORTED_RENDER_MODES.has(settings.renderMode)) {
+            throw new Error(`[SpriteBatch] Unsupported render mode: ${settings.renderMode}`);
+        }
+
         super(settings);
 
         this.maxParticles = 1000;
@@ -50,111 +92,104 @@ export class SpriteBatch extends VFXBatch {
         // TODO: implement boundingVolume
     }
 
-    buildExpandableBuffers(): void {
-        this.offsetBuffer = new InstancedBufferAttribute(new Float32Array(this.maxParticles * 3), 3);
-        this.offsetBuffer.setUsage(DynamicDrawUsage);
-        this.geometry.setAttribute('offset', this.offsetBuffer);
-        this.colorBuffer = new InstancedBufferAttribute(new Float32Array(this.maxParticles * 4), 4);
-        this.colorBuffer.setUsage(DynamicDrawUsage);
-        this.geometry.setAttribute('color', this.colorBuffer);
-        if (this.settings.renderMode === RenderMode.Mesh) {
-            this.rotationBuffer = new InstancedBufferAttribute(new Float32Array(this.maxParticles * 4), 4);
-            this.rotationBuffer.setUsage(DynamicDrawUsage);
-            this.geometry.setAttribute('rotation', this.rotationBuffer);
-        } else if (
-            this.settings.renderMode === RenderMode.BillBoard ||
-            this.settings.renderMode === RenderMode.HorizontalBillBoard ||
-            this.settings.renderMode === RenderMode.VerticalBillBoard ||
-            this.settings.renderMode === RenderMode.StretchedBillBoard
-        ) {
-            this.rotationBuffer = new InstancedBufferAttribute(new Float32Array(this.maxParticles), 1);
-            this.rotationBuffer.setUsage(DynamicDrawUsage);
-            this.geometry.setAttribute('rotation', this.rotationBuffer);
+    setupBuffers(): void {
+        this.geometry?.dispose();
+        this.geometry = new InstancedBufferGeometry();
+
+        const instancingGeometry = this.settings.instancingGeometry;
+        this.geometry.setIndex(instancingGeometry.getIndex());
+        this.geometry.setAttribute('position', instancingGeometry.getAttribute('position'));
+
+        if (instancingGeometry.hasAttribute('normal')) {
+            this.geometry.setAttribute('normal', instancingGeometry.getAttribute('normal'));
         }
-        this.sizeBuffer = new InstancedBufferAttribute(new Float32Array(this.maxParticles * 3), 3);
-        this.sizeBuffer.setUsage(DynamicDrawUsage);
-        this.geometry.setAttribute('size', this.sizeBuffer);
-        this.uvTileBuffer = new InstancedBufferAttribute(new Float32Array(this.maxParticles), 1);
-        this.uvTileBuffer.setUsage(DynamicDrawUsage);
-        this.geometry.setAttribute('uvTile', this.uvTileBuffer);
-        if (this.settings.renderMode === RenderMode.StretchedBillBoard) {
-            this.velocityBuffer = new InstancedBufferAttribute(new Float32Array(this.maxParticles * 4), 4);
-            this.velocityBuffer.setUsage(DynamicDrawUsage);
-            this.geometry.setAttribute('velocity', this.velocityBuffer);
+
+        if (instancingGeometry.hasAttribute('uv')) {
+            this.geometry.setAttribute('uv', instancingGeometry.getAttribute('uv'));
         }
+
+        this.buildExpandableBuffers();
     }
 
-    setupBuffers(): void {
-        if (this.geometry) this.geometry.dispose();
-        this.geometry = new InstancedBufferGeometry();
-        this.geometry.setIndex(this.settings.instancingGeometry.getIndex());
-        if (this.settings.instancingGeometry.hasAttribute('normal')) {
-            this.geometry.setAttribute('normal', this.settings.instancingGeometry.getAttribute('normal'));
+    buildExpandableBuffers(): void {
+        this.offsetBuffer = this.assignBufferAttribute('offset', this.maxParticles * 3, 3);
+        this.colorBuffer = this.assignBufferAttribute('color', this.maxParticles * 4, 4);
+        this.sizeBuffer = this.assignBufferAttribute('size', this.maxParticles * 3, 3);
+        this.uvTileBuffer = this.assignBufferAttribute('uvTile', this.maxParticles, 1);
+
+        if (this.settings.renderMode === RenderMode.Mesh) {
+            this.rotationBuffer = this.assignBufferAttribute('rotation', this.maxParticles * 4, 4);
+        } else {
+            this.rotationBuffer = this.assignBufferAttribute('rotation', this.maxParticles, 1);
+
+            if (this.settings.renderMode === RenderMode.StretchedBillBoard) {
+                this.velocityBuffer = this.assignBufferAttribute('velocity', this.maxParticles * 4, 4);
+            }
         }
-        this.geometry.setAttribute('position', this.settings.instancingGeometry.getAttribute('position')); //new InterleavedBufferAttribute(this.interleavedBuffer, 3, 0, false));
-        if (this.settings.instancingGeometry.hasAttribute('uv')) {
-            this.geometry.setAttribute('uv', this.settings.instancingGeometry.getAttribute('uv')); //new InterleavedBufferAttribute(this.interleavedBuffer, 2, 3, false));
-        }
-        this.buildExpandableBuffers();
     }
 
     expandBuffers(target: number): void {
         while (target >= this.maxParticles) {
             this.maxParticles *= 2;
         }
+
         this.setupBuffers();
     }
 
-    rebuildMaterial() {
+    rebuildMaterial(): void {
         this.layers.mask = this.settings.layers.mask;
 
+        const renderMode = this.settings.renderMode;
+        const isMesh = renderMode === RenderMode.Mesh;
+        const isStretchedBillBoard = renderMode === RenderMode.StretchedBillBoard;
+        const isVerticalBillBoard = renderMode === RenderMode.VerticalBillBoard;
+        const isHorizontalBillBoard = renderMode === RenderMode.HorizontalBillBoard;
+
+        const material = this.settings.material as any;
+        const isStandardMaterial = material.type === 'MeshStandardMaterial';
+        const isPhysicalMaterial = material.type === 'MeshPhysicalMaterial';
+        const isLitMesh = isMesh && (isStandardMaterial || isPhysicalMaterial);
+
         const uniforms: {[a: string]: Uniform} = {};
-        const defines: {[b: string]: string} = {};
+        const defines: {[b: string]: string} = {USE_UV: '', USE_COLOR_ALPHA: ''};
 
-        if (
-            this.settings.material.type !== 'MeshStandardMaterial' &&
-            this.settings.material.type !== 'MeshPhysicalMaterial'
-        ) {
-            uniforms['map'] = new Uniform((this.settings.material as any).map);
+        if (material.defines && material.defines['USE_COLOR_AS_ALPHA'] !== undefined) {
+            defines['USE_COLOR_AS_ALPHA'] = '';
         }
 
-        if ((this.settings.material as any).alphaTest) {
+        if (!isStandardMaterial && !isPhysicalMaterial) {
+            uniforms['map'] = new Uniform(material.map);
+        }
+
+        if (material.alphaTest) {
             defines['USE_ALPHATEST'] = '';
-            uniforms['alphaTest'] = new Uniform((this.settings.material as any).alphaTest);
+            uniforms['alphaTest'] = new Uniform(material.alphaTest);
         }
 
-        defines['USE_UV'] = '';
-        const uTileCount = this.settings.uTileCount;
-        const vTileCount = this.settings.vTileCount;
+        if (material.map) {
+            defines['USE_MAP'] = '';
+            defines['MAP_UV'] = getMaterialUVChannelName(material.map.channel);
+            if (this.settings.blendTiles) defines['TILE_BLEND'] = '';
+
+            uniforms['mapTransform'] = new Uniform(new Matrix3().copy(material.map.matrix));
+        }
+
+        if (material.normalMap) {
+            defines['USE_NORMALMAP'] = '';
+            defines['NORMALMAP_UV'] = getMaterialUVChannelName(material.normalMap.channel);
+
+            uniforms['normalMapTransform'] = new Uniform(new Matrix3().copy(material.normalMap.matrix));
+        }
+
+        const {uTileCount, vTileCount} = this.settings;
+
         if (uTileCount > 1 || vTileCount > 1) {
             defines['UV_TILE'] = '';
             uniforms['tileCount'] = new Uniform(new Vector2(uTileCount, vTileCount));
         }
 
-        if (
-            (this.settings.material as any).defines &&
-            (this.settings.material as any).defines['USE_COLOR_AS_ALPHA'] !== undefined
-        ) {
-            defines['USE_COLOR_AS_ALPHA'] = '';
-        }
+        let onBeforeRender: onBeforeRenderCallback | undefined;
 
-        if ((this.settings.material as any).normalMap) {
-            defines['USE_NORMALMAP'] = '';
-            defines['NORMALMAP_UV'] = getMaterialUVChannelName((this.settings.material as any).normalMap.channel);
-            uniforms['normalMapTransform'] = new Uniform(
-                new Matrix3().copy((this.settings.material as any).normalMap.matrix)
-            );
-        }
-
-        if ((this.settings.material as any).map) {
-            defines['USE_MAP'] = '';
-            if (this.settings.blendTiles) defines['TILE_BLEND'] = '';
-            defines['MAP_UV'] = getMaterialUVChannelName((this.settings.material as any).map.channel);
-            uniforms['mapTransform'] = new Uniform(new Matrix3().copy((this.settings.material as any).map.matrix));
-        }
-        defines['USE_COLOR_ALPHA'] = '';
-
-        let onBeforeRender;
         if (this.settings.softParticles) {
             defines['SOFT_PARTICLES'] = '';
 
@@ -163,88 +198,46 @@ export class SpriteBatch extends VFXBatch {
 
             uniforms['softParams'] = new Uniform(new Vector2(nearFade, invFadeDistance));
             uniforms['depthTexture'] = new Uniform(null);
-            const projParams = (uniforms['projParams'] = new Uniform(new Vector4()));
+            uniforms['projParams'] = new Uniform(new Vector4());
 
-            onBeforeRender = (_renderer: WebGLRenderer, _scene: Scene, camera: PerspectiveCamera) => {
-                projParams.value.set(camera.near, camera.far, 0, 0);
+            onBeforeRender = (_, __, camera) => {
+                uniforms['projParams'].value.set(camera.near, camera.far, 0, 0);
             };
         }
 
-        let needLights = false;
-        if (
-            this.settings.renderMode === RenderMode.BillBoard ||
-            this.settings.renderMode === RenderMode.VerticalBillBoard ||
-            this.settings.renderMode === RenderMode.HorizontalBillBoard ||
-            this.settings.renderMode === RenderMode.Mesh
-        ) {
-            let vertexShader;
-            let fragmentShader;
-            if (this.settings.renderMode === RenderMode.Mesh) {
-                if (
-                    this.settings.material.type === 'MeshStandardMaterial' ||
-                    this.settings.material.type === 'MeshPhysicalMaterial'
-                ) {
-                    defines['USE_COLOR'] = '';
-                    vertexShader = local_particle_physics_vert;
-                    fragmentShader = particle_physics_frag;
-                    needLights = true;
-                } else {
-                    vertexShader = local_particle_vert;
-                    fragmentShader = particle_frag;
-                }
-            } else {
-                vertexShader = particle_vert;
-                fragmentShader = particle_frag;
-            }
-            if (this.settings.renderMode === RenderMode.VerticalBillBoard) {
-                defines['VERTICAL'] = '';
-            } else if (this.settings.renderMode === RenderMode.HorizontalBillBoard) {
-                defines['HORIZONTAL'] = '';
-            }
+        if (isLitMesh) defines['USE_COLOR'] = '';
+        if (isVerticalBillBoard) defines['VERTICAL'] = '';
+        if (isHorizontalBillBoard) defines['HORIZONTAL'] = '';
 
-            let specialMats = false;
-            if (this.settings.renderMode === RenderMode.Mesh) {
-                //const mat = this.settings.material as MeshStandardMaterial;
-                if (this.settings.material.type === 'MeshStandardMaterial') {
-                    this.material = new ParticleMeshStandardMaterial({});
-                    this.material.copy(this.settings.material as MeshStandardMaterial);
-                    (this.material as any).uniforms = uniforms;
-                    (this.material as any).defines = defines;
-                    specialMats = true;
-                } else if (this.settings.material.type === 'MeshPhysicalMaterial') {
-                    this.material = new ParticleMeshPhysicsMaterial({});
-                    this.material.copy(this.settings.material as MeshPhysicalMaterial);
-                    (this.material as any).uniforms = uniforms;
-                    (this.material as any).defines = defines;
-                    specialMats = true;
-                }
-            }
-            if (!specialMats) {
-                this.material = new ShaderMaterial({
-                    uniforms: uniforms,
-                    defines: defines,
-                    vertexShader: vertexShader,
-                    fragmentShader: fragmentShader,
-                    transparent: this.settings.material.transparent,
-                    depthWrite: !this.settings.material.transparent,
-                    blending: this.settings.material.blending,
-                    blendDst: this.settings.material.blendDst,
-                    blendSrc: this.settings.material.blendSrc,
-                    blendEquation: this.settings.material.blendEquation,
-                    premultipliedAlpha: this.settings.material.premultipliedAlpha,
-                    side: this.settings.material.side,
-                    alphaTest: this.settings.material.alphaTest,
-                    depthTest: this.settings.material.depthTest,
-                    lights: needLights,
-                });
-            }
-        } else if (this.settings.renderMode === RenderMode.StretchedBillBoard) {
+        let vertexShader = particle_vert;
+        let fragmentShader = particle_frag;
+
+        if (isMesh) {
+            vertexShader = isLitMesh ? local_particle_physics_vert : local_particle_vert;
+            fragmentShader = isLitMesh ? particle_physics_frag : particle_frag;
+        }
+
+        if (isStretchedBillBoard) {
+            vertexShader = stretched_bb_particle_vert;
             uniforms['speedFactor'] = new Uniform(1.0);
+        }
+
+        if (isMesh && isStandardMaterial) {
+            this.material = new ParticleMeshStandardMaterial({});
+            this.material.copy(this.settings.material as MeshStandardMaterial);
+            (this.material as any).uniforms = uniforms;
+            (this.material as any).defines = defines;
+        } else if (isMesh && isPhysicalMaterial) {
+            this.material = new ParticleMeshPhysicsMaterial({});
+            this.material.copy(this.settings.material as MeshPhysicalMaterial);
+            (this.material as any).uniforms = uniforms;
+            (this.material as any).defines = defines;
+        } else {
             this.material = new ShaderMaterial({
                 uniforms: uniforms,
                 defines: defines,
-                vertexShader: stretched_bb_particle_vert,
-                fragmentShader: particle_frag,
+                vertexShader: vertexShader,
+                fragmentShader: fragmentShader,
                 transparent: this.settings.material.transparent,
                 depthWrite: !this.settings.material.transparent,
                 blending: this.settings.material.blending,
@@ -255,177 +248,180 @@ export class SpriteBatch extends VFXBatch {
                 side: this.settings.material.side,
                 alphaTest: this.settings.material.alphaTest,
                 depthTest: this.settings.material.depthTest,
+                lights: isLitMesh,
             });
-        } else {
-            throw new Error('render mode unavailable');
         }
-        if (this.material && onBeforeRender) {
+
+        if (onBeforeRender) {
             (this.material as any).onBeforeRender = onBeforeRender;
         }
     }
 
-    vector_: Vector3 = new Vector3();
-    vector2_: Vector3 = new Vector3();
-    vector3_: Vector3 = new Vector3();
-    quaternion_: Quaternion = new Quaternion();
-    quaternion2_: Quaternion = new Quaternion();
-    quaternion3_: Quaternion = new Quaternion();
-    rotationMat_: Matrix3 = new Matrix3();
-    rotationMat2_: Matrix3 = new Matrix3();
+    update(): void {
+        const visibleSystems = this.collectVisibleSystems(this._visibleSystems);
+        const particleCount = this.countParticles(visibleSystems);
 
-    update() {
-        let index = 0;
-
-        let particleCount = 0;
-
-        const visibleSystems = this.getVisibleSystems();
-        for (const system of visibleSystems) {
-            particleCount += system.particleNum;
-        }
         if (particleCount > this.maxParticles) {
             this.expandBuffers(particleCount);
         }
 
+        const renderMode = this.settings.renderMode;
+        const context = this._updateContext;
+
+        context.renderMode = renderMode;
+        context.velocityBuffer = renderMode === RenderMode.StretchedBillBoard ? this.velocityBuffer : undefined;
+        context.speedFactor = 0;
+        context.lengthFactor = 0;
+
+        let index = 0;
+
         for (const system of visibleSystems) {
-            if ((system.emitter as unknown as Object3D).updateMatrixWorld) {
-                (system.emitter as unknown as Object3D).updateWorldMatrix(true, false);
-                (system.emitter as unknown as Object3D).updateMatrixWorld(true);
-            }
-            const particles = system.particles;
-            const particleNum = system.particleNum;
-            const rotation = this.quaternion2_;
-            const translation = this.vector2_;
-            const scale = this.vector3_;
-            system.emitter.matrixWorld.decompose(translation, rotation, scale);
-            this.rotationMat_.setFromMatrix4(system.emitter.matrixWorld);
+            this.prepareUpdateContext(system, context);
+
+            const {particles, particleNum} = system;
 
             for (let j = 0; j < particleNum; j++, index++) {
                 const particle = particles[j] as SpriteParticle;
 
-                if (this.settings.renderMode === RenderMode.Mesh) {
-                    //this.quaternion_.setFromAxisAngle(UP, particle.rotation as number);
-                    let q;
-                    if (system.worldSpace) {
-                        q = particle.rotation as Quaternion;
-                    } else {
-                        let parentQ;
-                        if (particle.parentMatrix) {
-                            parentQ = this.quaternion3_.setFromRotationMatrix(particle.parentMatrix);
-                        } else {
-                            parentQ = rotation;
-                        }
-                        q = this.quaternion_;
-                        q.copy(parentQ).multiply(particle.rotation as Quaternion);
-                    }
-                    this.rotationBuffer.setXYZW(index, q.x, q.y, q.z, q.w);
-                } else if (
-                    this.settings.renderMode === RenderMode.StretchedBillBoard ||
-                    this.settings.renderMode === RenderMode.VerticalBillBoard ||
-                    this.settings.renderMode === RenderMode.HorizontalBillBoard ||
-                    this.settings.renderMode === RenderMode.BillBoard
-                ) {
-                    this.rotationBuffer.setX(index, particle.rotation as number);
-                }
-
-                let vec;
-                if (system.worldSpace) {
-                    vec = particle.position;
-                } else {
-                    vec = this.vector_;
-                    if (particle.parentMatrix) {
-                        vec.copy(particle.position).applyMatrix4(particle.parentMatrix);
-                    } else {
-                        vec.copy(particle.position).applyMatrix4(system.emitter.matrixWorld);
-                    }
-                }
-                this.offsetBuffer.setXYZ(index, vec.x, vec.y, vec.z);
-                this.colorBuffer.setXYZW(index, particle.color.x, particle.color.y, particle.color.z, particle.color.w);
-
-                if (system.worldSpace) {
-                    this.sizeBuffer.setXYZ(index, particle.size.x, particle.size.y, particle.size.z);
-                } else {
-                    if (particle.parentMatrix) {
-                        this.sizeBuffer.setXYZ(index, particle.size.x, particle.size.y, particle.size.z);
-                    } else {
-                        this.sizeBuffer.setXYZ(
-                            index,
-                            particle.size.x * Math.abs(scale.x),
-                            particle.size.y * Math.abs(scale.y),
-                            particle.size.z * Math.abs(scale.z),
-                        );
-                    }
-                }
-                this.uvTileBuffer.setX(index, particle.uvTile);
-
-                if (this.settings.renderMode === RenderMode.StretchedBillBoard && this.velocityBuffer) {
-                    let speedFactor = (system.rendererEmitterSettings as StretchedBillBoardSettings).speedFactor;
-                    if (speedFactor === 0) speedFactor = 0.001; // TODO: use an another buffer
-                    const lengthFactor = (system.rendererEmitterSettings as StretchedBillBoardSettings).lengthFactor;
-                    let vec;
-                    if (system.worldSpace) {
-                        vec = particle.velocity;
-                    } else {
-                        vec = this.vector_;
-                        if (particle.parentMatrix) {
-                            this.rotationMat2_.setFromMatrix4(particle.parentMatrix);
-                            vec.copy(particle.velocity).applyMatrix3(this.rotationMat2_);
-                        } else {
-                            vec.copy(particle.velocity).applyMatrix3(this.rotationMat_);
-                        }
-                    }
-                    this.velocityBuffer.setXYZW(
-                        index,
-                        vec.x * speedFactor,
-                        vec.y * speedFactor,
-                        vec.z * speedFactor,
-                        lengthFactor
-                    );
-                }
+                this.writeParticleRotation(index, particle, context);
+                this.writeParticleAttributes(index, particle, context);
+                this.writeParticleVelocity(index, particle, context);
             }
         }
+
         this.geometry.instanceCount = index;
+        this.updateBufferRanges(index);
+    }
 
-        if (index > 0) {
-            this.offsetBuffer.clearUpdateRanges();
-            this.offsetBuffer.addUpdateRange(0, index * 3);
-            this.offsetBuffer.needsUpdate = true;
+    private assignBufferAttribute(name: string, length: number, itemSize: number): InstancedBufferAttribute {
+        const attribute = new InstancedBufferAttribute(new Float32Array(length), itemSize);
+        attribute.setUsage(DynamicDrawUsage);
 
-            this.sizeBuffer.clearUpdateRanges();
-            this.sizeBuffer.addUpdateRange(0, index * 3);
-            this.sizeBuffer.needsUpdate = true;
+        this.geometry.setAttribute(name, attribute);
 
-            this.colorBuffer.clearUpdateRanges();
-            this.colorBuffer.addUpdateRange(0, index * 4);
-            this.colorBuffer.needsUpdate = true;
+        return attribute;
+    }
 
-            this.uvTileBuffer.clearUpdateRanges();
-            this.uvTileBuffer.addUpdateRange(0, index);
-            this.uvTileBuffer.needsUpdate = true;
+    private countParticles(systems: IParticleSystem[]): number {
+        let particleCount = 0;
 
-            if (this.settings.renderMode === RenderMode.StretchedBillBoard && this.velocityBuffer) {
-                this.velocityBuffer.clearUpdateRanges();
-                this.velocityBuffer.addUpdateRange(0, index * 4);
-                this.velocityBuffer.needsUpdate = true;
+        for (const system of systems) {
+            particleCount += system.particleNum;
+        }
+
+        return particleCount;
+    }
+
+    private prepareUpdateContext(system: IParticleSystem, context: SpriteBatchUpdateContext): void {
+        this.updateEmitterWorldMatrix(system);
+        const emitterMatrix = system.emitter.matrixWorld as Matrix4;
+        const rotation = this._qB;
+        const translation = this._vB;
+        const scale = this._vC;
+
+        emitterMatrix.decompose(translation, rotation, scale);
+        this._mA.setFromMatrix4(emitterMatrix);
+
+        context.worldSpace = system.worldSpace;
+        context.emitterMatrix = emitterMatrix;
+        context.emitterRotation = rotation;
+        context.emitterScale = scale;
+
+        if (!context.velocityBuffer) return;
+
+        const stretchedSettings = system.rendererEmitterSettings as StretchedBillBoardSettings;
+        const speedFactor = stretchedSettings.speedFactor;
+
+        context.speedFactor = speedFactor === 0 ? 0.001 : speedFactor; // TODO: use another buffer
+        context.lengthFactor = stretchedSettings.lengthFactor;
+    }
+
+    private writeParticleRotation(index: number, particle: SpriteParticle, context: SpriteBatchUpdateContext): void {
+        if (context.renderMode === RenderMode.Mesh) {
+            const q = context.worldSpace ? (particle.rotation as Quaternion) : this._qA;
+
+            if (!context.worldSpace) {
+                const parentMatrix = particle.parentMatrix;
+                const parentRotation = parentMatrix
+                    ? this._qC.setFromRotationMatrix(parentMatrix)
+                    : context.emitterRotation;
+
+                q.copy(parentRotation).multiply(particle.rotation as Quaternion);
             }
 
-            if (this.settings.renderMode === RenderMode.Mesh) {
-                this.rotationBuffer.clearUpdateRanges();
-                this.rotationBuffer.addUpdateRange(0, index * 4);
-                this.rotationBuffer.needsUpdate = true;
-            } else if (
-                this.settings.renderMode === RenderMode.StretchedBillBoard ||
-                this.settings.renderMode === RenderMode.HorizontalBillBoard ||
-                this.settings.renderMode === RenderMode.VerticalBillBoard ||
-                this.settings.renderMode === RenderMode.BillBoard
-            ) {
-                this.rotationBuffer.clearUpdateRanges();
-                this.rotationBuffer.addUpdateRange(0, index);
-                this.rotationBuffer.needsUpdate = true;
+            this.rotationBuffer.setXYZW(index, q.x, q.y, q.z, q.w);
+        } else {
+            this.rotationBuffer.setX(index, particle.rotation as number);
+        }
+    }
+
+    private writeParticleAttributes(index: number, particle: SpriteParticle, context: SpriteBatchUpdateContext): void {
+        const position = context.worldSpace
+            ? particle.position
+            : this._vA.copy(particle.position).applyMatrix4(particle.parentMatrix ?? context.emitterMatrix);
+
+        this.offsetBuffer.setXYZ(index, position.x, position.y, position.z);
+        this.colorBuffer.setXYZW(index, particle.color.x, particle.color.y, particle.color.z, particle.color.w);
+
+        if (context.worldSpace || particle.parentMatrix) {
+            this.sizeBuffer.setXYZ(index, particle.size.x, particle.size.y, particle.size.z);
+        } else {
+            const scale = context.emitterScale;
+
+            this.sizeBuffer.setXYZ(
+                index,
+                particle.size.x * Math.abs(scale.x),
+                particle.size.y * Math.abs(scale.y),
+                particle.size.z * Math.abs(scale.z)
+            );
+        }
+
+        this.uvTileBuffer.setX(index, particle.uvTile);
+    }
+
+    private writeParticleVelocity(index: number, particle: SpriteParticle, context: SpriteBatchUpdateContext): void {
+        const velocityBuffer = context.velocityBuffer;
+        if (!velocityBuffer) return;
+
+        const velocity = context.worldSpace ? particle.velocity : this._vA;
+
+        if (!context.worldSpace) {
+            const parentMatrix = particle.parentMatrix;
+            const rotationMatrix = parentMatrix ? this._mB.setFromMatrix4(parentMatrix) : this._mA;
+
+            velocity.copy(particle.velocity).applyMatrix3(rotationMatrix);
+        }
+
+        velocityBuffer.setXYZW(
+            index,
+            velocity.x * context.speedFactor,
+            velocity.y * context.speedFactor,
+            velocity.z * context.speedFactor,
+            context.lengthFactor
+        );
+    }
+
+    private updateBufferRanges(index: number): void {
+        if (index === 0) return;
+
+        updateBufferAttribute(this.offsetBuffer, 0, index * 3);
+        updateBufferAttribute(this.sizeBuffer, 0, index * 3);
+        updateBufferAttribute(this.colorBuffer, 0, index * 4);
+        updateBufferAttribute(this.uvTileBuffer, 0, index);
+
+        if (this.settings.renderMode === RenderMode.Mesh) {
+            updateBufferAttribute(this.rotationBuffer, 0, index * 4);
+        } else {
+            updateBufferAttribute(this.rotationBuffer, 0, index);
+
+            if (this.settings.renderMode === RenderMode.StretchedBillBoard && this.velocityBuffer) {
+                updateBufferAttribute(this.velocityBuffer, 0, index * 4);
             }
         }
     }
 
-    dispose() {
+    dispose(): void {
         this.geometry.dispose();
+        this._visibleSystems.length = 0;
     }
 }

--- a/packages/three.quarks/src/SpriteBatch.ts
+++ b/packages/three.quarks/src/SpriteBatch.ts
@@ -22,8 +22,7 @@ import {
     WebGLRenderer,
 } from 'three';
 
-import {VFXBatchSettings} from './BatchedRenderer';
-import {RenderMode, VFXBatch} from './VFXBatch';
+import {RenderMode, VFXBatch, type VFXBatchSettings} from './VFXBatch';
 import {ParticleMeshPhysicsMaterial, ParticleMeshStandardMaterial} from './materials/ParticleMaterials';
 import local_particle_physics_vert from './shaders/local_particle_physics_vert.glsl';
 import local_particle_vert from './shaders/local_particle_vert.glsl';

--- a/packages/three.quarks/src/TrailBatch.ts
+++ b/packages/three.quarks/src/TrailBatch.ts
@@ -10,11 +10,10 @@ import {
     UniformsUtils,
 } from 'three';
 
-import {VFXBatchSettings} from './BatchedRenderer';
 import trail_frag from './shaders/trail_frag.glsl';
 import trail_vert from './shaders/trail_vert.glsl';
 import {getMaterialUVChannelName, updateBufferAttribute} from './util/ThreeUtil';
-import {RenderMode, VFXBatch} from './VFXBatch';
+import {RenderMode, VFXBatch, type VFXBatchSettings} from './VFXBatch';
 
 const DEFAULT_MATERIAL_UNIFORMS = {
     lineWidth: {value: 1},

--- a/packages/three.quarks/src/TrailBatch.ts
+++ b/packages/three.quarks/src/TrailBatch.ts
@@ -1,24 +1,44 @@
-import {Matrix4, Quaternion, RecordState, Matrix3,TrailParticle, Vector3,Vector2} from 'quarks.core';
+import {IParticleSystem, Matrix3, Matrix4, Quaternion, RecordState, TrailParticle, Vector2, Vector3} from 'quarks.core';
 import {
     AdditiveBlending,
+    BufferAttribute,
+    BufferGeometry,
+    DynamicDrawUsage,
+    IUniform,
     ShaderMaterial,
     Uniform,
-    DynamicDrawUsage,
-    BufferGeometry,
-    BufferAttribute, Object3D,
+    UniformsUtils,
 } from 'three';
 
+import {VFXBatchSettings} from './BatchedRenderer';
 import trail_frag from './shaders/trail_frag.glsl';
 import trail_vert from './shaders/trail_vert.glsl';
-import {VFXBatch, RenderMode} from './VFXBatch';
-import {getMaterialUVChannelName} from './util/ThreeUtil';
-import {VFXBatchSettings} from './BatchedRenderer';
+import {getMaterialUVChannelName, updateBufferAttribute} from './util/ThreeUtil';
+import {RenderMode, VFXBatch} from './VFXBatch';
+
+const DEFAULT_MATERIAL_UNIFORMS = {
+    lineWidth: {value: 1},
+    map: {value: null},
+    useMap: {value: 0},
+    alphaMap: {value: null},
+    useAlphaMap: {value: 0},
+    resolution: {value: new Vector2(1, 1)},
+    sizeAttenuation: {value: 1},
+    visibility: {value: 1},
+    alphaTest: {value: 0},
+} satisfies Record<string, IUniform>;
 
 /**
- * A VFX batch that render trails in a batch.
+ * A VFX batch that renders trails.
  */
 export class TrailBatch extends VFXBatch {
     declare geometry: BufferGeometry;
+
+    private readonly _vA: Vector3 = new Vector3();
+    private readonly _vB: Vector3 = new Vector3();
+    private readonly _vC: Vector3 = new Vector3();
+    private readonly _qA: Quaternion = new Quaternion();
+    private readonly _visibleSystems: IParticleSystem[] = [];
 
     private positionBuffer!: BufferAttribute;
     private previousBuffer!: BufferAttribute;
@@ -39,308 +59,264 @@ export class TrailBatch extends VFXBatch {
     }
 
     setupBuffers(): void {
-        if (this.geometry) this.geometry.dispose();
+        this.geometry?.dispose();
         this.geometry = new BufferGeometry();
+
         this.indexBuffer = new BufferAttribute(new Uint32Array(this.maxParticles * 6), 1);
         this.indexBuffer.setUsage(DynamicDrawUsage);
         this.geometry.setIndex(this.indexBuffer);
 
-        this.positionBuffer = new BufferAttribute(new Float32Array(this.maxParticles * 6), 3);
-        this.positionBuffer.setUsage(DynamicDrawUsage);
-        this.geometry.setAttribute('position', this.positionBuffer);
-        this.previousBuffer = new BufferAttribute(new Float32Array(this.maxParticles * 6), 3);
-        this.previousBuffer.setUsage(DynamicDrawUsage);
-        this.geometry.setAttribute('previous', this.previousBuffer);
-        this.nextBuffer = new BufferAttribute(new Float32Array(this.maxParticles * 6), 3);
-        this.nextBuffer.setUsage(DynamicDrawUsage);
-        this.geometry.setAttribute('next', this.nextBuffer);
-        this.widthBuffer = new BufferAttribute(new Float32Array(this.maxParticles * 2), 1);
-        this.widthBuffer.setUsage(DynamicDrawUsage);
-        this.geometry.setAttribute('width', this.widthBuffer);
-        this.sideBuffer = new BufferAttribute(new Float32Array(this.maxParticles * 2), 1);
-        this.sideBuffer.setUsage(DynamicDrawUsage);
-        this.geometry.setAttribute('side', this.sideBuffer);
-        this.uvBuffer = new BufferAttribute(new Float32Array(this.maxParticles * 4), 2);
-        this.uvBuffer.setUsage(DynamicDrawUsage);
-        this.geometry.setAttribute('uv', this.uvBuffer);
-        this.colorBuffer = new BufferAttribute(new Float32Array(this.maxParticles * 8), 4);
-        this.colorBuffer.setUsage(DynamicDrawUsage);
-        this.geometry.setAttribute('color', this.colorBuffer);
+        this.positionBuffer = this.assignBufferAttribute('position', this.maxParticles * 6, 3);
+        this.previousBuffer = this.assignBufferAttribute('previous', this.maxParticles * 6, 3);
+        this.nextBuffer = this.assignBufferAttribute('next', this.maxParticles * 6, 3);
+        this.widthBuffer = this.assignBufferAttribute('width', this.maxParticles * 2, 1);
+        this.sideBuffer = this.assignBufferAttribute('side', this.maxParticles * 2, 1);
+        this.uvBuffer = this.assignBufferAttribute('uv', this.maxParticles * 4, 2);
+        this.colorBuffer = this.assignBufferAttribute('color', this.maxParticles * 8, 4);
     }
 
     expandBuffers(target: number): void {
         while (target >= this.maxParticles) {
             this.maxParticles *= 2;
         }
+
         this.setupBuffers();
     }
 
-    rebuildMaterial() {
-        this.layers.mask = this.settings.layers.mask;
-
-        const uniforms: {[a: string]: {value: any}} = {
-            lineWidth: {value: 1},
-            map: {value: null},
-            useMap: {value: 0},
-            alphaMap: {value: null},
-            useAlphaMap: {value: 0},
-            resolution: {value: new Vector2(1, 1)},
-            sizeAttenuation: {value: 1},
-            visibility: {value: 1},
-            alphaTest: {value: 0},
-            //repeat: {value: new Vector2(1, 1)},
-        };
-        const defines: {[b: string]: string} = {};
-
-        defines['USE_UV'] = '';
-        defines['USE_COLOR_ALPHA'] = '';
-
-        if ((this.settings.material as any).map) {
-            defines['USE_MAP'] = '';
-            defines['MAP_UV'] = getMaterialUVChannelName((this.settings.material as any).map.channel);
-            uniforms['map'] = new Uniform((this.settings.material as any).map);
-            uniforms['mapTransform'] = new Uniform(new Matrix3().copy((this.settings.material as any).map.matrix));
+    rebuildMaterial(): void {
+        if (this.settings.renderMode !== RenderMode.Trail) {
+            throw new Error(`[TrailBatch] Unsupported render mode: ${this.settings.renderMode}`);
         }
 
-        if (
-            (this.settings.material as any).defines &&
-            (this.settings.material as any).defines['USE_COLOR_AS_ALPHA'] !== undefined
-        ) {
+        this.layers.mask = this.settings.layers.mask;
+
+        const uniforms: Record<string, IUniform> = UniformsUtils.clone(DEFAULT_MATERIAL_UNIFORMS);
+        const material = this.settings.material as any;
+        const defines: {[b: string]: string} = {USE_UV: '', USE_COLOR_ALPHA: ''};
+
+        if (material.map) {
+            defines['USE_MAP'] = '';
+            defines['MAP_UV'] = getMaterialUVChannelName(material.map.channel);
+
+            uniforms['map'] = new Uniform(material.map);
+            uniforms['mapTransform'] = new Uniform(new Matrix3().copy(material.map.matrix));
+        }
+
+        if (material.defines && material.defines['USE_COLOR_AS_ALPHA'] !== undefined) {
             defines['USE_COLOR_AS_ALPHA'] = '';
         }
 
-        if (this.settings.renderMode === RenderMode.Trail) {
-            this.material = new ShaderMaterial({
-                uniforms: uniforms,
-                defines: defines,
-                vertexShader: trail_vert,
-                fragmentShader: trail_frag,
-                transparent: this.settings.material.transparent,
-                depthWrite: !this.settings.material.transparent,
-                side: this.settings.material.side,
-                blending: this.settings.material.blending || AdditiveBlending,
-                blendDst: this.settings.material.blendDst,
-                blendSrc: this.settings.material.blendSrc,
-                blendEquation: this.settings.material.blendEquation,
-                premultipliedAlpha: this.settings.material.premultipliedAlpha,
-            });
-        } else {
-            throw new Error('render mode unavailable');
-        }
+        this.material = new ShaderMaterial({
+            uniforms: uniforms,
+            defines: defines,
+            vertexShader: trail_vert,
+            fragmentShader: trail_frag,
+            transparent: material.transparent,
+            depthWrite: !material.transparent,
+            side: material.side,
+            blending: material.blending || AdditiveBlending,
+            blendDst: material.blendDst,
+            blendSrc: material.blendSrc,
+            blendEquation: material.blendEquation,
+            premultipliedAlpha: material.premultipliedAlpha,
+        });
     }
 
-    /*
-    clone() {
-        let system = this.system.clone();
-        return system.emitter as any;
-    }*/
-    vector_: Vector3 = new Vector3();
-    vector2_: Vector3 = new Vector3();
-    vector3_: Vector3 = new Vector3();
-    quaternion_: Quaternion = new Quaternion();
+    update(): void {
+        let vertexIndex = 0;
+        let triangleCount = 0;
 
-    update() {
-        let index = 0;
-        let triangles = 0;
+        const visibleSystems = this.collectVisibleSystems(this._visibleSystems);
+        const particleCount = this.countTrailPoints(visibleSystems);
 
-        let particleCount = 0;
-        const visibleSystems = this.getVisibleSystems();
-        for (const system of visibleSystems) {
-            for (let j = 0; j < system.particleNum; j++) {
-                particleCount += (system.particles[j] as TrailParticle).previous.length * 2;
-            }
-        }
         if (particleCount > this.maxParticles) {
             this.expandBuffers(particleCount);
         }
 
+        const {uTileCount, vTileCount} = this.settings;
+        const tileWidth = 1 / uTileCount;
+        const tileHeight = 1 / vTileCount;
+
+        const translation = this._vB;
+        const rotation = this._qA;
+        const scale = this._vC;
+
         for (const system of visibleSystems) {
-            if ((system.emitter as unknown as Object3D).updateMatrixWorld) {
-                (system.emitter as unknown as Object3D).updateWorldMatrix(true, false);
-                (system.emitter as unknown as Object3D).updateMatrixWorld(true);
-            }
-            const rotation = this.quaternion_;
-            const translation = this.vector2_;
-            const scale = this.vector3_;
-            system.emitter.matrixWorld.decompose(translation, rotation, scale);
+            this.updateEmitterWorldMatrix(system);
 
-            const particles = system.particles;
-            const particleNum = system.particleNum;
+            const worldSpace = system.worldSpace;
+            const emitterMatrix = system.emitter.matrixWorld;
+            emitterMatrix.decompose(translation, rotation, scale);
 
-            const uTileCount = this.settings.uTileCount;
-            const vTileCount = this.settings.vTileCount;
+            const objectScale = (Math.abs(scale.x) + Math.abs(scale.y) + Math.abs(scale.z)) / 3;
 
-            const tileWidth = 1 / uTileCount;
-            const tileHeight = 1 / vTileCount;
-
-            for (let j = 0; j < particleNum; j++) {
-                const particle = particles[j] as TrailParticle;
-                const col = particle.uvTile % vTileCount;
-                const row = Math.floor(particle.uvTile / vTileCount + 0.001);
+            for (let j = 0; j < system.particleNum; j++) {
+                const particle = system.particles[j] as TrailParticle;
+                const trailLength = particle.previous.length;
+                if (trailLength === 0) continue;
 
                 const iter = particle.previous.values();
                 let curIter = iter.next();
+
+                // Duplicate the first and last records at the trail ends for stable shader tangents.
                 let previous: RecordState = curIter.value as RecordState;
                 let current: RecordState = previous;
-                if (!curIter.done) curIter = iter.next();
                 let next: RecordState;
+
+                if (!curIter.done) curIter = iter.next();
+
                 if (curIter.value !== undefined) {
                     next = curIter.value;
                 } else {
                     next = current;
                 }
-                for (let i = 0; i < particle.previous.length; i++, index += 2) {
-                    this.positionBuffer.setXYZ(index, current.position.x, current.position.y, current.position.z);
-                    this.positionBuffer.setXYZ(index + 1, current.position.x, current.position.y, current.position.z);
 
-                    if (system.worldSpace) {
-                        this.positionBuffer.setXYZ(index, current.position.x, current.position.y, current.position.z);
-                        this.positionBuffer.setXYZ(
-                            index + 1,
-                            current.position.x,
-                            current.position.y,
-                            current.position.z
-                        );
-                    } else {
-                        if (particle.parentMatrix) {
-                            this.vector_.copy(current.position).applyMatrix4(particle.parentMatrix as unknown as Matrix4);
-                        } else {
-                            this.vector_.copy(current.position).applyMatrix4(system.emitter.matrixWorld);
-                        }
-                        this.positionBuffer.setXYZ(index, this.vector_.x, this.vector_.y, this.vector_.z);
-                        this.positionBuffer.setXYZ(index + 1, this.vector_.x, this.vector_.y, this.vector_.z);
-                    }
+                const parentMatrix = particle.parentMatrix;
+                const col = particle.uvTile % vTileCount;
+                const row = Math.floor(particle.uvTile / vTileCount + 0.001);
 
-                    if (system.worldSpace) {
-                        this.previousBuffer.setXYZ(
-                            index,
-                            previous.position.x,
-                            previous.position.y,
-                            previous.position.z
-                        );
-                        this.previousBuffer.setXYZ(
-                            index + 1,
-                            previous.position.x,
-                            previous.position.y,
-                            previous.position.z
-                        );
-                    } else {
-                        if (particle.parentMatrix) {
-                            this.vector_.copy(previous.position).applyMatrix4(particle.parentMatrix);
-                        } else {
-                            this.vector_.copy(previous.position).applyMatrix4(system.emitter.matrixWorld);
-                        }
-                        this.previousBuffer.setXYZ(index, this.vector_.x, this.vector_.y, this.vector_.z);
-                        this.previousBuffer.setXYZ(index + 1, this.vector_.x, this.vector_.y, this.vector_.z);
-                    }
-
-                    if (system.worldSpace) {
-                        this.nextBuffer.setXYZ(index, next.position.x, next.position.y, next.position.z);
-                        this.nextBuffer.setXYZ(index + 1, next.position.x, next.position.y, next.position.z);
-                    } else {
-                        if (particle.parentMatrix) {
-                            this.vector_.copy(next.position).applyMatrix4(particle.parentMatrix);
-                        } else {
-                            this.vector_.copy(next.position).applyMatrix4(system.emitter.matrixWorld);
-                        }
-                        this.nextBuffer.setXYZ(index, this.vector_.x, this.vector_.y, this.vector_.z);
-                        this.nextBuffer.setXYZ(index + 1, this.vector_.x, this.vector_.y, this.vector_.z);
-                    }
-
-                    this.sideBuffer.setX(index, 1);
-                    this.sideBuffer.setX(index + 1, -1);
-
-                    if (system.worldSpace) {
-                        this.widthBuffer.setX(index, current.size);
-                        this.widthBuffer.setX(index + 1, current.size);
-                    } else {
-                        if (particle.parentMatrix) {
-                            this.widthBuffer.setX(index, current.size);
-                            this.widthBuffer.setX(index + 1, current.size);
-                        } else {
-                            const objectScale = (Math.abs(scale.x) + Math.abs(scale.y) + Math.abs(scale.z)) / 3;
-                            this.widthBuffer.setX(index, current.size * objectScale);
-                            this.widthBuffer.setX(index + 1, current.size * objectScale);
-                        }
-                    }
-
-                    this.uvBuffer.setXY(
-                        index,
-                        (i / particle.previous.length + col) * tileWidth,
-                        (vTileCount - row - 1) * tileHeight
-                    );
-                    this.uvBuffer.setXY(
-                        index + 1,
-                        (i / particle.previous.length + col) * tileWidth,
-                        (vTileCount - row) * tileHeight
+                for (let trailIndex = 0; trailIndex < trailLength; trailIndex++, vertexIndex += 2) {
+                    this.writeTrailPosition(
+                        this.positionBuffer,
+                        vertexIndex,
+                        current.position,
+                        worldSpace,
+                        parentMatrix,
+                        emitterMatrix
                     );
 
-                    this.colorBuffer.setXYZW(index, current.color.x, current.color.y, current.color.z, current.color.w);
+                    this.writeTrailPosition(
+                        this.previousBuffer,
+                        vertexIndex,
+                        previous.position,
+                        worldSpace,
+                        parentMatrix,
+                        emitterMatrix
+                    );
+
+                    this.writeTrailPosition(
+                        this.nextBuffer,
+                        vertexIndex,
+                        next.position,
+                        worldSpace,
+                        parentMatrix,
+                        emitterMatrix
+                    );
+
+                    const width = !worldSpace && !parentMatrix ? current.size * objectScale : current.size;
+                    const u = (trailIndex / trailLength + col) * tileWidth;
+                    const nextVertexIndex = vertexIndex + 1;
+
+                    this.sideBuffer.setX(vertexIndex, 1);
+                    this.sideBuffer.setX(nextVertexIndex, -1);
+
+                    this.widthBuffer.setX(vertexIndex, width);
+                    this.widthBuffer.setX(nextVertexIndex, width);
+
+                    this.uvBuffer.setXY(vertexIndex, u, (vTileCount - row - 1) * tileHeight);
+                    this.uvBuffer.setXY(nextVertexIndex, u, (vTileCount - row) * tileHeight);
+
                     this.colorBuffer.setXYZW(
-                        index + 1,
+                        vertexIndex,
+                        current.color.x,
+                        current.color.y,
+                        current.color.z,
+                        current.color.w
+                    );
+                    this.colorBuffer.setXYZW(
+                        nextVertexIndex,
                         current.color.x,
                         current.color.y,
                         current.color.z,
                         current.color.w
                     );
 
-                    if (i + 1 < particle.previous.length) {
-                        this.indexBuffer.setX(triangles * 3, index);
-                        this.indexBuffer.setX(triangles * 3 + 1, index + 1);
-                        this.indexBuffer.setX(triangles * 3 + 2, index + 2);
-                        triangles++;
-                        this.indexBuffer.setX(triangles * 3, index + 2);
-                        this.indexBuffer.setX(triangles * 3 + 1, index + 1);
-                        this.indexBuffer.setX(triangles * 3 + 2, index + 3);
-                        triangles++;
+                    if (trailIndex + 1 < trailLength) {
+                        this.writeTrailIndices(vertexIndex, triangleCount);
+                        triangleCount += 2;
                     }
+
                     previous = current;
                     current = next;
-                    if (!curIter.done) {
-                        curIter = iter.next();
-                        if (curIter.value !== undefined) {
-                            next = curIter.value;
-                        }
+
+                    if (curIter.done) continue;
+
+                    curIter = iter.next();
+
+                    if (curIter.value !== undefined) {
+                        next = curIter.value;
                     }
                 }
             }
         }
-        this.positionBuffer.clearUpdateRanges();
-        this.positionBuffer.addUpdateRange(0, index * 3);
-        this.positionBuffer.needsUpdate = true;
 
-        this.previousBuffer.clearUpdateRanges();
-        this.previousBuffer.addUpdateRange(0, index * 3);
-        this.previousBuffer.needsUpdate = true;
+        this.updateBufferRanges(vertexIndex, triangleCount);
+    }
 
-        this.nextBuffer.clearUpdateRanges();
-        this.nextBuffer.addUpdateRange(0, index * 3);
-        this.nextBuffer.needsUpdate = true;
+    private assignBufferAttribute(name: string, length: number, itemSize: number): BufferAttribute {
+        const attribute = new BufferAttribute(new Float32Array(length), itemSize);
+        attribute.setUsage(DynamicDrawUsage);
 
-        this.sideBuffer.clearUpdateRanges();
-        this.sideBuffer.addUpdateRange(0, index);
-        this.sideBuffer.needsUpdate = true;
+        this.geometry.setAttribute(name, attribute);
 
-        this.widthBuffer.clearUpdateRanges();
-        this.widthBuffer.addUpdateRange(0, index);
-        this.widthBuffer.needsUpdate = true;
+        return attribute;
+    }
 
-        this.uvBuffer.clearUpdateRanges();
-        this.uvBuffer.addUpdateRange(0, index * 2);
-        this.uvBuffer.needsUpdate = true;
+    private countTrailPoints(systems: IParticleSystem[]): number {
+        let particleCount = 0;
 
-        this.colorBuffer.clearUpdateRanges();
-        this.colorBuffer.addUpdateRange(0, index * 4);
-        this.colorBuffer.needsUpdate = true;
+        for (const system of systems) {
+            for (let j = 0; j < system.particleNum; j++) {
+                particleCount += (system.particles[j] as TrailParticle).previous.length * 2;
+            }
+        }
 
-        this.indexBuffer.clearUpdateRanges();
-        this.indexBuffer.addUpdateRange(0, triangles * 3);
-        this.indexBuffer.needsUpdate = true;
+        return particleCount;
+    }
 
-        this.geometry.setDrawRange(0, triangles * 3);
+    private writeTrailIndices(vertexIndex: number, triangleCount: number): void {
+        const triangleOffset = triangleCount * 3;
+
+        this.indexBuffer.setX(triangleOffset, vertexIndex);
+        this.indexBuffer.setX(triangleOffset + 1, vertexIndex + 1);
+        this.indexBuffer.setX(triangleOffset + 2, vertexIndex + 2);
+        this.indexBuffer.setX(triangleOffset + 3, vertexIndex + 2);
+        this.indexBuffer.setX(triangleOffset + 4, vertexIndex + 1);
+        this.indexBuffer.setX(triangleOffset + 5, vertexIndex + 3);
+    }
+
+    private updateBufferRanges(vertexIndex: number, triangleCount: number): void {
+        const vertexIndexTimesThree = vertexIndex * 3;
+        const triangleOffset = triangleCount * 3;
+
+        updateBufferAttribute(this.positionBuffer, 0, vertexIndexTimesThree);
+        updateBufferAttribute(this.previousBuffer, 0, vertexIndexTimesThree);
+        updateBufferAttribute(this.nextBuffer, 0, vertexIndexTimesThree);
+        updateBufferAttribute(this.sideBuffer, 0, vertexIndex);
+        updateBufferAttribute(this.widthBuffer, 0, vertexIndex);
+        updateBufferAttribute(this.uvBuffer, 0, vertexIndex * 2);
+        updateBufferAttribute(this.colorBuffer, 0, vertexIndex * 4);
+        updateBufferAttribute(this.indexBuffer, 0, triangleOffset);
+
+        this.geometry.setDrawRange(0, triangleOffset);
+    }
+
+    private writeTrailPosition(
+        buffer: BufferAttribute,
+        index: number,
+        position: Vector3,
+        worldSpace: boolean,
+        parentMatrix: Matrix4 | undefined,
+        emitterMatrix: Matrix4
+    ): void {
+        const transformed = worldSpace ? position : this._vA.copy(position).applyMatrix4(parentMatrix ?? emitterMatrix);
+
+        buffer.setXYZ(index, transformed.x, transformed.y, transformed.z);
+        buffer.setXYZ(index + 1, transformed.x, transformed.y, transformed.z);
     }
 
     dispose() {
         this.geometry.dispose();
+        this._visibleSystems.length = 0;
     }
 }

--- a/packages/three.quarks/src/VFXBatch.ts
+++ b/packages/three.quarks/src/VFXBatch.ts
@@ -1,9 +1,8 @@
-import {Mesh, ShaderMaterial, BufferGeometry, Material, Layers, Texture, Object3D} from 'three';
-import {VFXBatchSettings} from './BatchedRenderer';
 import {IParticleSystem} from 'quarks.core';
+import {BufferGeometry, Layers, Material, Mesh, ShaderMaterial, Texture} from 'three';
+import {VFXBatchSettings} from './BatchedRenderer';
 
 export interface StoredBatchSettings {
-    // 5 component x,y,z,u,v
     instancingGeometry: BufferGeometry;
     material: Material;
     uTileCount: number;
@@ -16,6 +15,7 @@ export interface StoredBatchSettings {
     renderOrder: number;
     layers: Layers;
 }
+
 /**
  * Enum representing the render modes for particles.
  */
@@ -50,36 +50,22 @@ export enum RenderMode {
  * Base class for VFX batches.
  */
 export abstract class VFXBatch extends Mesh {
-    type = 'VFXBatch';
-    systems: Set<IParticleSystem>;
+    readonly type = 'VFXBatch';
 
-    settings: StoredBatchSettings;
-    protected maxParticles;
+    readonly systems: Set<IParticleSystem> = new Set();
+    readonly settings: StoredBatchSettings;
+
+    protected maxParticles = 1000;
 
     protected constructor(settings: VFXBatchSettings) {
         super();
-        this.maxParticles = 1000;
-        this.systems = new Set<IParticleSystem>();
-        const layers = new Layers();
-        layers.mask = settings.layers.mask;
-        const newMat = settings.material.clone();
-        newMat.defines = {};
-        Object.assign(newMat.defines, settings.material.defines);
-        this.settings = {
-            instancingGeometry: settings.instancingGeometry,
-            renderMode: settings.renderMode,
-            renderOrder: settings.renderOrder,
-            material: newMat,
-            uTileCount: settings.uTileCount,
-            vTileCount: settings.vTileCount,
-            blendTiles: settings.blendTiles,
-            softParticles: settings.softParticles,
-            softNearFade: settings.softNearFade,
-            softFarFade: settings.softFarFade,
-            layers: layers,
-        };
+
+        const layers = this.createLayersWithMask(settings.layers.mask);
+        const material = this.cloneBatchMaterial(settings.material);
+        this.settings = this.storeBatchSettings(settings, material, layers);
+
         this.frustumCulled = false;
-        this.renderOrder = this.settings.renderOrder;
+        this.renderOrder = settings.renderOrder;
     }
 
     addSystem(system: IParticleSystem) {
@@ -91,17 +77,16 @@ export abstract class VFXBatch extends Mesh {
     }
 
     applyDepthTexture(depthTexture: Texture | null): void {
-        const uniform = (this.material as ShaderMaterial).uniforms['depthTexture'];
-        if (uniform) {
-            if (uniform.value !== depthTexture) {
-                uniform.value = depthTexture;
-                (this.material as ShaderMaterial).needsUpdate = true;
-            }
-        }
+        const material = this.material as ShaderMaterial;
+        const uniform = material.uniforms['depthTexture'];
+        if (!uniform || uniform.value === depthTexture) return;
+
+        uniform.value = depthTexture;
+        material.needsUpdate = true;
     }
 
     getVisibleSystems(): IParticleSystem[] {
-        return Array.from(this.systems).filter((system) => system.emitter.visible);
+        return [...this.systems].filter((system) => system.emitter.visible);
     }
 
     abstract setupBuffers(): void;
@@ -110,9 +95,34 @@ export abstract class VFXBatch extends Mesh {
     abstract update(): void;
     abstract dispose(): void;
 
-    /*
-    clone() {
-        let system = this.system.clone();
-        return system.emitter as any;
-    }*/
+    private createLayersWithMask(mask: number): Layers {
+        const layers = new Layers();
+        layers.mask = mask;
+
+        return layers;
+    }
+
+    private cloneBatchMaterial(material: Material): Material {
+        const clone = material.clone();
+        clone.defines = {};
+        Object.assign(clone.defines, material.defines);
+
+        return clone;
+    }
+
+    private storeBatchSettings(settings: VFXBatchSettings, material: Material, layers: Layers): StoredBatchSettings {
+        return {
+            instancingGeometry: settings.instancingGeometry,
+            renderMode: settings.renderMode,
+            renderOrder: settings.renderOrder,
+            material,
+            uTileCount: settings.uTileCount,
+            vTileCount: settings.vTileCount,
+            blendTiles: settings.blendTiles,
+            softParticles: settings.softParticles,
+            softNearFade: settings.softNearFade,
+            softFarFade: settings.softFarFade,
+            layers,
+        };
+    }
 }

--- a/packages/three.quarks/src/VFXBatch.ts
+++ b/packages/three.quarks/src/VFXBatch.ts
@@ -1,20 +1,73 @@
 import {IParticleSystem} from 'quarks.core';
 import {BufferGeometry, Layers, Material, Mesh, Object3D, ShaderMaterial, Texture} from 'three';
-import {VFXBatchSettings} from './BatchedRenderer';
 
-export interface StoredBatchSettings {
+/**
+ * Settings for rendering a batch of VFX systems.
+ */
+export interface VFXBatchSettings {
+    /**
+     * Geometry for instancing.
+     * @type {BufferGeometry}
+     */
     instancingGeometry: BufferGeometry;
+    /**
+     * Material for rendering.
+     * @type {Material}
+     */
     material: Material;
+    /**
+     * Number of horizontal tiles in the texture.
+     * @type {number}
+     */
     uTileCount: number;
+    /**
+     * Number of vertical tiles in the texture.
+     * @type {number}
+     */
     vTileCount: number;
+    /**
+     * Whether to blend tiles.
+     * @type {boolean}
+     */
     blendTiles: boolean;
+    /**
+     * Enable soft particles.
+     * @type {boolean}
+     */
     softParticles: boolean;
+    /**
+     * Near fade distance for soft particles.
+     * @type {number}
+     */
     softNearFade: number;
+    /**
+     * Far fade distance for soft particles.
+     * @type {number}
+     */
     softFarFade: number;
+    /**
+     * Render mode.
+     * @type {RenderMode}
+     */
     renderMode: RenderMode;
+    /**
+     * Render order.
+     * @type {number}
+     */
     renderOrder: number;
+    /**
+     * Layers control the visibility of the object.
+     * @type {Layers}
+     * @see {@link https://threejs.org/docs/index.html#api/en/core/Layers | Official Documentation}
+     * @see {@link https://github.com/mrdoob/three.js/blob/master/src/core/Layers.js | Source}
+     */
     layers: Layers;
 }
+
+/**
+ * Batch settings snapshot stored after material and layer settings are cloned.
+ */
+export type StoredBatchSettings = VFXBatchSettings;
 
 /**
  * Enum representing the render modes for particles.

--- a/packages/three.quarks/src/VFXBatch.ts
+++ b/packages/three.quarks/src/VFXBatch.ts
@@ -1,5 +1,5 @@
 import {IParticleSystem} from 'quarks.core';
-import {BufferGeometry, Layers, Material, Mesh, ShaderMaterial, Texture} from 'three';
+import {BufferGeometry, Layers, Material, Mesh, Object3D, ShaderMaterial, Texture} from 'three';
 import {VFXBatchSettings} from './BatchedRenderer';
 
 export interface StoredBatchSettings {
@@ -85,8 +85,28 @@ export abstract class VFXBatch extends Mesh {
         material.needsUpdate = true;
     }
 
+    protected collectVisibleSystems(out: IParticleSystem[]): IParticleSystem[] {
+        out.length = 0;
+
+        for (const system of this.systems) {
+            if (system.emitter.visible) {
+                out.push(system);
+            }
+        }
+
+        return out;
+    }
+
+    protected updateEmitterWorldMatrix(system: IParticleSystem): void {
+        const emitter = system.emitter as unknown as Object3D;
+        if (typeof emitter.updateMatrixWorld !== 'function') return;
+
+        emitter.updateWorldMatrix(true, false);
+        emitter.updateMatrixWorld(true);
+    }
+
     getVisibleSystems(): IParticleSystem[] {
-        return [...this.systems].filter((system) => system.emitter.visible);
+        return this.collectVisibleSystems([]);
     }
 
     abstract setupBuffers(): void;

--- a/packages/three.quarks/src/index.ts
+++ b/packages/three.quarks/src/index.ts
@@ -1,22 +1,24 @@
-import { MeshSurfaceEmitterPlugin } from './MeshSurfaceEmitter';
+import {loadPlugin} from 'quarks.core';
+import {MeshSurfaceEmitterPlugin} from './MeshSurfaceEmitter';
 import {registerShaderChunks} from './shaders';
-import { loadPlugin } from 'quarks.core';
+
+export * from 'quarks.core';
+export * from './BatchedParticleRenderer';
+export * from './BatchedRenderer';
+export * from './materials/';
+export * from './MeshSurfaceEmitter';
 export * from './ParticleEmitter';
 export * from './ParticleSystem';
-export * from './VFXBatch';
-export * from './SpriteBatch';
-export * from './TrailBatch';
-export * from './MeshSurfaceEmitter';
-export * from './BatchedRenderer';
-export * from './BatchedParticleRenderer';
 export * from './QuarksLoader';
 export * from './QuarksPrefab';
 export * from './QuarksUtil';
 export * from './shaders/';
-export * from './materials/';
-export * from 'quarks.core';
+export * from './SpriteBatch';
+export * from './TrailBatch';
+export * from './VFXBatch';
 
 registerShaderChunks();
 loadPlugin(MeshSurfaceEmitterPlugin);
-// remove this line if you have pro license
+
+// Remove this line if you have pro license
 console.log('%c Particle system powered by three.quarks. https://quarks.art/', 'font-size: 14px; font-weight: bold;');

--- a/packages/three.quarks/src/materials/index.ts
+++ b/packages/three.quarks/src/materials/index.ts
@@ -1,1 +1,1 @@
-export * from "./ParticleMaterials";
+export * from './ParticleMaterials';

--- a/packages/three.quarks/src/util/RendererDefaults.ts
+++ b/packages/three.quarks/src/util/RendererDefaults.ts
@@ -1,0 +1,73 @@
+import {
+    AxisAngleGenerator,
+    ConstantValue,
+    FunctionValueGenerator,
+    RendererEmitterSettings,
+    RotationGenerator,
+    ValueGenerator,
+    Vector3,
+} from 'quarks.core';
+import {BufferGeometry, PlaneGeometry} from 'three';
+
+import {RenderMode} from '../VFXBatch';
+
+export interface RenderModeDefaults {
+    rendererEmitterSettings?: RendererEmitterSettings;
+    instancingGeometry?: BufferGeometry;
+    startRotation?: ValueGenerator | FunctionValueGenerator | RotationGenerator;
+}
+
+/**
+ * Renderer defaults and render-mode-specific settings construction.
+ */
+export class RendererDefaults {
+    private static readonly DEFAULT_GEOMETRY = new PlaneGeometry(1, 1, 1, 1);
+
+    static getDefaultGeometry(): BufferGeometry {
+        return RendererDefaults.DEFAULT_GEOMETRY;
+    }
+
+    static createRenderModeTransitionDefaults(
+        previousRenderMode: RenderMode,
+        renderMode: RenderMode
+    ): RenderModeDefaults {
+        const defaults = RendererDefaults.createRenderModeDefaults(renderMode);
+
+        if (previousRenderMode === RenderMode.Mesh && renderMode !== RenderMode.Mesh) {
+            defaults.startRotation = new ConstantValue(0);
+        }
+
+        return defaults;
+    }
+
+    private static createRenderModeDefaults(renderMode: RenderMode): RenderModeDefaults {
+        switch (renderMode) {
+            case RenderMode.Trail:
+                return {
+                    rendererEmitterSettings: {
+                        startLength: new ConstantValue(30),
+                        followLocalOrigin: false,
+                    },
+                };
+            case RenderMode.Mesh:
+                return {
+                    rendererEmitterSettings: {geometry: RendererDefaults.DEFAULT_GEOMETRY},
+                    startRotation: new AxisAngleGenerator(new Vector3(0, 1, 0), new ConstantValue(0)),
+                };
+            case RenderMode.StretchedBillBoard:
+                return {
+                    rendererEmitterSettings: {speedFactor: 0, lengthFactor: 2},
+                    instancingGeometry: RendererDefaults.DEFAULT_GEOMETRY,
+                };
+            case RenderMode.BillBoard:
+            case RenderMode.VerticalBillBoard:
+            case RenderMode.HorizontalBillBoard:
+                return {
+                    rendererEmitterSettings: {},
+                    instancingGeometry: RendererDefaults.DEFAULT_GEOMETRY,
+                };
+            default:
+                return {};
+        }
+    }
+}

--- a/packages/three.quarks/src/util/ThreeUtil.ts
+++ b/packages/three.quarks/src/util/ThreeUtil.ts
@@ -1,4 +1,4 @@
-import { BufferGeometry, Material, Texture } from "three";
+import {BufferAttribute, BufferGeometry, Material, Texture} from 'three';
 
 export type ThreeMetaData = {
     textures: {[uuid: string]: Texture};
@@ -9,4 +9,23 @@ export type ThreeMetaData = {
 export function getMaterialUVChannelName(value: number): string {
     if (value === 0) return 'uv';
     return `uv${value}`;
+}
+
+/**
+ * Marks a buffer attribute range for upload.
+ * @param buffer - The buffer attribute to update.
+ * @param updateRangeStart - The update range start offset in attribute components.
+ * @param updateRangeCount - The number of attribute components to update.
+ * @returns The same buffer attribute.
+ */
+export function updateBufferAttribute<TBuffer extends BufferAttribute>(
+    buffer: TBuffer,
+    updateRangeStart: number,
+    updateRangeCount: number
+): TBuffer {
+    buffer.clearUpdateRanges();
+    buffer.addUpdateRange(updateRangeStart, updateRangeCount);
+    buffer.needsUpdate = true;
+
+    return buffer;
 }

--- a/packages/three.quarks/test/BatchedRenderer.test.ts
+++ b/packages/three.quarks/test/BatchedRenderer.test.ts
@@ -9,6 +9,8 @@ import {
     RenderMode,
     SizeOverLife,
     SphereEmitter,
+    SpriteBatch,
+    TrailBatch,
 } from '../src';
 import {Vector3, Vector4} from 'quarks.core';
 import {MeshBasicMaterial, NormalBlending, Scene, Texture} from 'three';
@@ -111,5 +113,33 @@ describe('BatchedRenderer', () => {
 
         expect(glowBeam.particleNum).toEqual(previousCount);
         expect(renderer.batches[0].systems.size).toEqual(0);
+    });
+
+    test('render mode changes move systems between batch types', () => {
+        const scene = new Scene();
+        const renderer = new BatchedRenderer();
+        const system = new ParticleSystem({
+            material: new MeshBasicMaterial(),
+            renderMode: RenderMode.BillBoard,
+        });
+
+        renderer.addSystem(system);
+        scene.add(system.emitter);
+        scene.add(renderer);
+
+        renderer.update(0);
+        expect(renderer.batches[0]).toBeInstanceOf(SpriteBatch);
+        expect(renderer.batches[0].systems.has(system)).toBe(true);
+
+        system.renderMode = RenderMode.Trail;
+        renderer.update(0);
+        expect(renderer.batches[0].systems.has(system)).toBe(false);
+        expect(renderer.batches[1]).toBeInstanceOf(TrailBatch);
+        expect(renderer.batches[1].systems.has(system)).toBe(true);
+
+        system.renderMode = RenderMode.BillBoard;
+        renderer.update(0);
+        expect(renderer.batches[0].systems.has(system)).toBe(true);
+        expect(renderer.batches[1].systems.has(system)).toBe(false);
     });
 });

--- a/packages/three.quarks/test/ParticleEmitter.test.ts
+++ b/packages/three.quarks/test/ParticleEmitter.test.ts
@@ -101,14 +101,58 @@ describe('ParticleEmitter', () => {
     });
 
     test('.clone', () => {
-        const newPS = glowBeam.clone();
+        const system = new ParticleSystem({
+            duration: 1,
+            looping: true,
+            prewarm: true,
+            startLife: new IntervalValue(0.1, 0.15),
+            startSpeed: new ConstantValue(0),
+            startSize: new ConstantValue(3.5),
+            startColor: new ConstantColor(new Vector4(1, 0.1509503, 0.07352942, 0.5)),
+            rendererEmitterSettings: {startLength: new ConstantValue(40)},
+            worldSpace: true,
+            emissionOverTime: new ConstantValue(40),
+            emissionBursts: [
+                {
+                    time: 0.5,
+                    count: new ConstantValue(7),
+                    probability: 1,
+                    interval: 0.1,
+                    cycle: 1,
+                },
+            ],
+            shape: new SphereEmitter({
+                radius: 0.0001,
+                thickness: 1,
+                arc: Math.PI * 2,
+            }),
+            material: new MeshBasicMaterial({map: texture, blending: NormalBlending, transparent: true}),
+            startTileIndex: new ConstantValue(1),
+            uTileCount: 10,
+            vTileCount: 10,
+            renderOrder: 2,
+            renderMode: RenderMode.Trail,
+            layers: layers,
+        });
+        system.addBehavior(new SizeOverLife(new PiecewiseBezier([[new Bezier(1, 0.95, 0.75, 0), 0]])));
+        system.addBehavior(new ApplyForce(new Vector3(0, 1, 0), new ConstantValue(10)));
+
+        const newPS = system.clone();
         expect(newPS.layers.mask).toBe(3);
-        expect(newPS.behaviors.length).toBe(glowBeam.behaviors.length);
-        expect(newPS.blending).toBe(glowBeam.blending);
-        expect(newPS.rendererSettings.renderOrder).toBe(glowBeam.rendererSettings.renderOrder);
-        expect((newPS.rendererEmitterSettings as TrailSettings).startLength.type).toBe(
-            (newPS.rendererEmitterSettings as TrailSettings).startLength.type
-        );
+        expect(newPS.behaviors.length).toBe(system.behaviors.length);
+        expect(newPS.blending).toBe(system.blending);
+        expect(newPS.rendererSettings.renderOrder).toBe(system.rendererSettings.renderOrder);
+        const originalTrailSettings = system.rendererEmitterSettings as TrailSettings;
+        const clonedTrailSettings = newPS.rendererEmitterSettings as TrailSettings;
+
+        expect(clonedTrailSettings.startLength).not.toBe(originalTrailSettings.startLength);
+        expect(clonedTrailSettings.startLength.type).toBe(originalTrailSettings.startLength.type);
+        expect(newPS.prewarm).toBe(true);
+        expect(newPS.startTileIndex).not.toBe(system.startTileIndex);
+        expect(newPS.emissionBursts).toHaveLength(1);
+        expect(newPS.emissionBursts[0]).not.toBe(system.emissionBursts[0]);
+        expect(newPS.emissionBursts[0].count).not.toBe(system.emissionBursts[0].count);
+        expect((newPS.emissionBursts[0].count as ConstantValue).value).toBe(7);
     });
 
     test('event listeners are unique and removable', () => {

--- a/packages/three.quarks/test/ParticleEmitter.test.ts
+++ b/packages/three.quarks/test/ParticleEmitter.test.ts
@@ -111,6 +111,25 @@ describe('ParticleEmitter', () => {
         );
     });
 
+    test('event listeners are unique and removable', () => {
+        const system = new ParticleSystem({material: new MeshBasicMaterial()});
+        const listener = jest.fn();
+
+        system.addEventListener('emitEnd', listener);
+        system.addEventListener('emitEnd', listener);
+        system.endEmit();
+        expect(listener).toHaveBeenCalledTimes(1);
+
+        system.removeEventListener('emitEnd', listener);
+        system.endEmit();
+        expect(listener).toHaveBeenCalledTimes(1);
+
+        system.addEventListener('emitEnd', listener);
+        system.removeAllEventListeners('emitEnd');
+        system.endEmit();
+        expect(listener).toHaveBeenCalledTimes(1);
+    });
+
     test('.fromJSON', () => {
         // const meta = { geometries: {}, materials: {}, textures: {}, images: {} };
         const json = glowBeam.emitter.toJSON();

--- a/packages/three.quarks/test/ParticleSystem.test.ts
+++ b/packages/three.quarks/test/ParticleSystem.test.ts
@@ -1,7 +1,15 @@
 /**
  * @jest-environment jsdom
  */
-import {ParticleSystem, RenderMode, SpriteParticle, StretchedBillBoardSettings, TrailSettings} from '../src';
+import {
+    ConstantValue,
+    Matrix4,
+    ParticleSystem,
+    RenderMode,
+    SpriteParticle,
+    StretchedBillBoardSettings,
+    TrailSettings,
+} from '../src';
 import {BufferGeometry, MeshBasicMaterial} from 'three';
 
 describe('ParticleSystem', () => {
@@ -72,5 +80,32 @@ describe('ParticleSystem', () => {
         expect(system.paused).toBe(false);
         expect(system.emissionState.time).toBe(0);
         expect((system.rendererEmitterSettings as TrailSettings).startLength.type).toBe('value');
+    });
+
+    test('restart clears distance emission state', () => {
+        const system = new ParticleSystem({
+            material: new MeshBasicMaterial(),
+            emissionOverTime: new ConstantValue(0),
+            emissionOverDistance: new ConstantValue(0.5),
+        });
+        const emitterMatrix = new Matrix4();
+
+        system.emit(0, system.emissionState, emitterMatrix);
+        emitterMatrix.elements[12] = 1;
+        system.emit(0, system.emissionState, emitterMatrix);
+
+        expect(system.emissionState.travelDistance).toBe(1);
+        expect(system.emissionState.previousWorldPos).toBeDefined();
+
+        system.restart();
+
+        expect(system.emissionState.travelDistance).toBe(0);
+        expect(system.emissionState.previousWorldPos).toBeUndefined();
+
+        emitterMatrix.elements[12] = 3;
+        system.emit(0, system.emissionState, emitterMatrix);
+
+        expect(system.emissionState.waitEmiting).toBe(0);
+        expect(system.emissionState.travelDistance).toBe(0);
     });
 });

--- a/packages/three.quarks/test/ParticleSystem.test.ts
+++ b/packages/three.quarks/test/ParticleSystem.test.ts
@@ -3,14 +3,74 @@
  */
 import {
     ConstantValue,
+    EmissionState,
+    FunctionColorGenerator,
+    FunctionValueGenerator,
+    GeneratorMemory,
     Matrix4,
     ParticleSystem,
     RenderMode,
     SpriteParticle,
     StretchedBillBoardSettings,
     TrailSettings,
+    Vector4,
 } from '../src';
 import {BufferGeometry, MeshBasicMaterial} from 'three';
+
+class RecordingValueGenerator implements FunctionValueGenerator {
+    readonly type = 'function';
+    readonly times: number[] = [];
+
+    constructor(private readonly value: number) {}
+
+    startGen(memory: GeneratorMemory): void {}
+
+    genValue(memory: GeneratorMemory, t: number): number {
+        this.times.push(t);
+        return this.value;
+    }
+
+    toJSON() {
+        return {type: 'RecordingValueGenerator'};
+    }
+
+    clone(): FunctionValueGenerator {
+        return new RecordingValueGenerator(this.value);
+    }
+}
+
+class RecordingColorGenerator implements FunctionColorGenerator {
+    readonly type = 'function';
+    readonly times: number[] = [];
+
+    startGen(memory: GeneratorMemory): void {}
+
+    genColor(memory: GeneratorMemory, color: Vector4, t: number): Vector4 {
+        this.times.push(t);
+        return color.set(1, 1, 1, 1);
+    }
+
+    toJSON() {
+        return {type: 'RecordingColorGenerator'};
+    }
+
+    clone(): FunctionColorGenerator {
+        return new RecordingColorGenerator();
+    }
+}
+
+function createEmissionState(time: number): EmissionState {
+    return {
+        isBursting: false,
+        burstIndex: 0,
+        burstWaveIndex: 0,
+        burstParticleIndex: 0,
+        burstParticleCount: 0,
+        time,
+        waitEmiting: 0,
+        travelDistance: 0,
+    };
+}
 
 describe('ParticleSystem', () => {
     test('constructor initializes stretched billboard renderer emitter settings', () => {
@@ -107,5 +167,32 @@ describe('ParticleSystem', () => {
 
         expect(system.emissionState.waitEmiting).toBe(0);
         expect(system.emissionState.travelDistance).toBe(0);
+    });
+
+    test('emit uses the provided emission state time for sub-emission generators', () => {
+        const burstCount = new RecordingValueGenerator(1);
+        const startColor = new RecordingColorGenerator();
+        const system = new ParticleSystem({
+            material: new MeshBasicMaterial(),
+            duration: 0.5,
+            startColor,
+            emissionOverTime: new ConstantValue(0),
+            emissionOverDistance: new ConstantValue(0),
+            emissionBursts: [
+                {
+                    time: 0.25,
+                    count: burstCount,
+                    cycle: 1,
+                    interval: 0.1,
+                    probability: 1,
+                },
+            ],
+        });
+
+        system.emissionState.time = 0.75;
+        system.emit(0, createEmissionState(0.25), new Matrix4());
+
+        expect(burstCount.times).toEqual([0.25]);
+        expect(startColor.times).toEqual([0.5]);
     });
 });

--- a/packages/three.quarks/test/ParticleSystem.test.ts
+++ b/packages/three.quarks/test/ParticleSystem.test.ts
@@ -1,10 +1,35 @@
 /**
  * @jest-environment jsdom
  */
-import {ParticleSystem, RenderMode, SpriteParticle, TrailSettings} from '../src';
+import {ParticleSystem, RenderMode, SpriteParticle, StretchedBillBoardSettings, TrailSettings} from '../src';
 import {BufferGeometry, MeshBasicMaterial} from 'three';
 
 describe('ParticleSystem', () => {
+    test('constructor initializes stretched billboard renderer emitter settings', () => {
+        const rendererEmitterSettings = {} as StretchedBillBoardSettings;
+        const system = new ParticleSystem({
+            material: new MeshBasicMaterial(),
+            renderMode: RenderMode.StretchedBillBoard,
+            rendererEmitterSettings,
+            speedFactor: 3,
+        });
+
+        expect(system.rendererEmitterSettings).toBe(rendererEmitterSettings);
+        expect(rendererEmitterSettings.speedFactor).toBe(3);
+        expect(rendererEmitterSettings.lengthFactor).toBe(0);
+
+        const existingSettings = {speedFactor: 2, lengthFactor: 4};
+        const existingSettingsSystem = new ParticleSystem({
+            material: new MeshBasicMaterial(),
+            renderMode: RenderMode.StretchedBillBoard,
+            rendererEmitterSettings: existingSettings,
+        });
+
+        expect(existingSettingsSystem.rendererEmitterSettings).toBe(existingSettings);
+        expect(existingSettings.speedFactor).toBe(2);
+        expect(existingSettings.lengthFactor).toBe(4);
+    });
+
     test('renderMode applies mode defaults and marks renderer settings dirty', () => {
         const instancingGeometry = new BufferGeometry();
         const system = new ParticleSystem({

--- a/packages/three.quarks/test/ParticleSystem.test.ts
+++ b/packages/three.quarks/test/ParticleSystem.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+import {ParticleSystem, RenderMode, SpriteParticle, TrailSettings} from '../src';
+import {BufferGeometry, MeshBasicMaterial} from 'three';
+
+describe('ParticleSystem', () => {
+    test('renderMode applies mode defaults and marks renderer settings dirty', () => {
+        const instancingGeometry = new BufferGeometry();
+        const system = new ParticleSystem({
+            material: new MeshBasicMaterial(),
+            instancingGeometry,
+        });
+
+        system.neededToUpdateRender = false;
+        system.renderMode = RenderMode.Mesh;
+        expect(system.renderMode).toBe(RenderMode.Mesh);
+        expect(system.rendererSettings.instancingGeometry).toBe(instancingGeometry);
+        expect(system.startRotation.type).toBe('rotation');
+        expect(system.neededToUpdateRender).toBe(true);
+
+        system.neededToUpdateRender = false;
+        system.renderMode = RenderMode.BillBoard;
+        expect(system.renderMode).toBe(RenderMode.BillBoard);
+        expect(system.rendererSettings.instancingGeometry).not.toBe(instancingGeometry);
+        expect(system.rendererEmitterSettings).toEqual({});
+        expect(system.startRotation.type).toBe('value');
+        expect(system.neededToUpdateRender).toBe(true);
+    });
+
+    test('renderMode restarts active particles for trail transitions', () => {
+        const system = new ParticleSystem({material: new MeshBasicMaterial()});
+
+        system.particles.push(new SpriteParticle());
+        system.particleNum = 1;
+        system.paused = true;
+        system.emissionState.time = 1;
+
+        system.renderMode = RenderMode.HorizontalBillBoard;
+        expect(system.particleNum).toBe(1);
+        expect(system.particles).toHaveLength(1);
+        expect(system.emissionState.time).toBe(1);
+
+        system.renderMode = RenderMode.Trail;
+        expect(system.particleNum).toBe(0);
+        expect(system.particles).toHaveLength(0);
+        expect(system.paused).toBe(false);
+        expect(system.emissionState.time).toBe(0);
+        expect((system.rendererEmitterSettings as TrailSettings).startLength.type).toBe('value');
+    });
+});

--- a/packages/three.quarks/test/QuarksPrefab.test.ts
+++ b/packages/three.quarks/test/QuarksPrefab.test.ts
@@ -96,7 +96,13 @@ describe('QuarksPrefab', () => {
             
             const newPrefab = QuarksPrefab.fromJSON(json.object);
             expect(newPrefab).toBeInstanceOf(QuarksPrefab);
-            expect((newPrefab as any)._tempAnimationJSON).toHaveLength(2);
+
+            newPrefab.resolveReferences(prefab);
+
+            expect(newPrefab.animationData).toHaveLength(2);
+            expect(newPrefab.animationData[0].target).toBe(targetObject);
+            expect(newPrefab.animationData[0].clip).toBe(animationClip);
+            expect(newPrefab.animationData[1].target).toBe(particleEmitter);
         });
     });
 
@@ -118,6 +124,35 @@ describe('QuarksPrefab', () => {
             prefab.stop();
             expect(prefab.isPlaying).toBe(false);
             expect(prefab.currentTime).toBeLessThanOrEqual(0);
+        });
+
+        it('should update shared target mixers once per frame', () => {
+            const xTrack = new NumberKeyframeTrack('.position[x]', [0, 1], [0, 1]);
+            const yTrack = new NumberKeyframeTrack('.position[y]', [0, 1], [0, 1]);
+            const xClip = new AnimationClip('x', 1, [xTrack]);
+            const yClip = new AnimationClip('y', 1, [yTrack]);
+
+            const animation = prefab.addThreeAnimation(targetObject, xClip, 0, 1);
+            prefab.addThreeAnimation(targetObject, yClip, 0, 1);
+
+            const updateSpy = jest.spyOn(animation.mixer!, 'update');
+
+            prefab.play();
+            prefab.update(0.5);
+
+            expect(updateSpy).toHaveBeenCalledTimes(1);
+            expect(updateSpy).toHaveBeenCalledWith(0.5);
+        });
+
+        it('should treat exact animation end time as outside when seeking', () => {
+            const animation = prefab.addThreeAnimation(targetObject, animationClip, 1, 2);
+            const playSpy = jest.spyOn(animation.action!, 'play');
+            const updateSpy = jest.spyOn(animation.mixer!, 'update');
+
+            prefab.setTime(3);
+
+            expect(playSpy).not.toHaveBeenCalled();
+            expect(updateSpy).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/three.quarks/test/VFXBatch.test.ts
+++ b/packages/three.quarks/test/VFXBatch.test.ts
@@ -1,8 +1,8 @@
 import {IParticleSystem} from 'quarks.core';
 import {BufferGeometry, Layers, MeshBasicMaterial, Object3D} from 'three';
 
-import {VFXBatchSettings} from '../src/BatchedRenderer';
 import {RenderMode, VFXBatch} from '../src/VFXBatch';
+import type {VFXBatchSettings} from '../src/VFXBatch';
 
 class TestBatch extends VFXBatch {
     constructor() {

--- a/packages/three.quarks/test/VFXBatch.test.ts
+++ b/packages/three.quarks/test/VFXBatch.test.ts
@@ -1,0 +1,78 @@
+import {IParticleSystem} from 'quarks.core';
+import {BufferGeometry, Layers, MeshBasicMaterial, Object3D} from 'three';
+
+import {VFXBatchSettings} from '../src/BatchedRenderer';
+import {RenderMode, VFXBatch} from '../src/VFXBatch';
+
+class TestBatch extends VFXBatch {
+    constructor() {
+        super(createBatchSettings());
+    }
+
+    collect(out: IParticleSystem[]): IParticleSystem[] {
+        return this.collectVisibleSystems(out);
+    }
+
+    setupBuffers(): void {}
+    expandBuffers(target: number): void {}
+    rebuildMaterial(): void {}
+    update(): void {}
+    dispose(): void {}
+}
+
+function createBatchSettings(): VFXBatchSettings {
+    return {
+        instancingGeometry: new BufferGeometry(),
+        material: new MeshBasicMaterial(),
+        uTileCount: 1,
+        vTileCount: 1,
+        blendTiles: false,
+        softParticles: false,
+        softNearFade: 0,
+        softFarFade: 0,
+        renderMode: RenderMode.BillBoard,
+        renderOrder: 0,
+        layers: new Layers(),
+    };
+}
+
+function createSystem(visible: boolean): IParticleSystem {
+    const emitter = new Object3D();
+    emitter.visible = visible;
+
+    return {emitter} as unknown as IParticleSystem;
+}
+
+describe('VFXBatch', () => {
+    test('getVisibleSystems returns a fresh visible-system array', () => {
+        const batch = new TestBatch();
+        const visible = createSystem(true);
+        const hidden = createSystem(false);
+
+        batch.addSystem(visible);
+        batch.addSystem(hidden);
+
+        const first = batch.getVisibleSystems();
+        const second = batch.getVisibleSystems();
+
+        expect(first).toEqual([visible]);
+        expect(second).toEqual([visible]);
+        expect(first).not.toBe(second);
+    });
+
+    test('collectVisibleSystems clears and reuses the provided array', () => {
+        const batch = new TestBatch();
+        const stale = createSystem(true);
+        const visible = createSystem(true);
+        const hidden = createSystem(false);
+        const scratch = [stale];
+
+        batch.addSystem(visible);
+        batch.addSystem(hidden);
+
+        const result = batch.collect(scratch);
+
+        expect(result).toBe(scratch);
+        expect(result).toEqual([visible]);
+    });
+});


### PR DESCRIPTION
## Overview

The main goal is to make the runtime internals easier to reason about: renderer batching, loader/prefab restoration, mesh-surface emission, sprite/trail batches, and `ParticleSystem` now have clearer responsibilities, fewer inline nested helper blocks, and more explicit state transitions. Most changes are intended to preserve behavior; the functional fixes are isolated and covered by tests.

### Maintainability

- Clarified `BatchedRenderer`, `VFXBatch`, `SpriteBatch`, and `TrailBatch` setup/update flow.
- Consolidated `VFXBatchSettings` ownership under `VFXBatch`, with a `BatchedRenderer` type re-export to preserve existing type imports.
- Added shared helpers for visible-system collection, emitter world-matrix refresh, and buffer attribute update ranges.
- Split `MeshSurfaceEmitter` area-table rebuild and particle sampling into named helpers.
- Cleaned up `QuarksLoader` reference collection/linking and moved parse-object resource resolution into private helpers.
- Split `QuarksPrefab` animation update, seek, JSON restore, and target resolution paths into focused helpers.
- Reworked `ParticleSystem` construction, renderer default setup, spawn, update, emit, and clone paths into smaller named steps.
- Normalized barrel exports, imports, JSDoc, stale comments, array syntax, and private scratch-state placement.

### Performance

- Added allocation-free visible-system collection for batch update paths while preserving `getVisibleSystems()` fresh-array behavior.
- Reused scratch context/state in `SpriteBatch`, `TrailBatch`, `VFXBatch`, and `QuarksPrefab` hot paths.
- Reused trail `localPosition` vectors instead of allocating on every respawn.
- Avoided `ParticleSystem` event object allocation when no listeners are registered.
- Replaced `forEach` usage in repeated animation/runtime paths with direct loops.
- Hoisted repeated calculations out of loops where possible.

### Correctness fixes

- Avoid duplicate particle-emitter traversal when the root object is itself a `ParticleEmitter`.
- Preserve `ParticleSystem` clone state more accurately (`prewarm`, `startTileIndex`, emission burst count generators, renderer emitter settings independence)
- Reset mutable emission state on restart, including burst counters, distance emission state, and previous world position.
- Use the provided `EmissionState` time for sub-emission burst counts and spawn color initialization.
- Preserve serialized `MeshSurfaceEmitter` compatibility by accepting both `mesh` and `geometry` keys.
- Store `ParticleSystem` listeners in sets to avoid duplicate callback registration.

## Notes

The `ParticleSystem` section is intentionally split into several commits because it contains both readability work and real bug fixes.

Tests pass and examples run without issues.